### PR TITLE
Fix line feeds in German translation

### DIFF
--- a/AndorsTrail/assets/translation/de.po
+++ b/AndorsTrail/assets/translation/de.po
@@ -32325,7 +32325,7 @@ msgstr ""
 msgid ""
 "The key is cursed .... She ... I am ... (Crackshot finally dies, emitting a soft bluish breath)\n"
 ""
-msgstr "Der Schlüssel ist verflucht ... Sie ... Ich bin ... (Crackshot stirbt endlich, einen schwach bläulichen Atem ausstossend)"
+msgstr "Der Schlüssel ist verflucht ... Sie ... Ich bin ... (Crackshot stirbt endlich, einen schwach bläulichen Atem ausstossend)\n"
 
 #: conversationlist_omicronrg9.json:guild03_hideout3_exit_3:0
 msgid "Bah .... Too many questions. I need to come back."
@@ -32624,7 +32624,7 @@ msgstr "Du brauchst mir nichts zu erzählen, was ich mit eigenen Augen sehen kan
 msgid ""
 "I expect more of you. That was your first mission inside the guild and you failed it!\n"
 ""
-msgstr "Ich erwarte mehr von dir. Das war deine erste Mission innerhalb der Gilde und du hast versagt!"
+msgstr "Ich erwarte mehr von dir. Das war deine erste Mission innerhalb der Gilde und du hast versagt!\n"
 
 #: conversationlist_omicronrg9.json:umar_guild02_30:0
 msgid "I brought a valuable necklace from the noblewoman."
@@ -32638,7 +32638,7 @@ msgstr "Ein guter Lügner zu sein, ist eine wertvolle Fähigkeit für die Gilde,
 msgid ""
 "What we have here? (Umar's face gets a smile while he admires the necklace)\n"
 ""
-msgstr "Was haben wir denn hier? (Auf Umars Gesicht zeigt sich ein Lächeln als er die Halskette bewundert)"
+msgstr "Was haben wir denn hier? (Auf Umars Gesicht zeigt sich ein Lächeln als er die Halskette bewundert)\n"
 
 #: conversationlist_omicronrg9.json:umar_guild02_32
 msgid "Well. I will take it as compensation for your mistakes."


### PR DESCRIPTION
This request fixes compilation of translations. The error is:
```
assets/translation/de.po:32328: 'msgid' and 'msgstr' entries do not both end with '\n'
assets/translation/de.po:32627: 'msgid' and 'msgstr' entries do not both end with '\n'
assets/translation/de.po:32641: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 3 fatal errors
```