### PR TITLE
Fix factionScore requirement

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/script/Requirement.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/script/Requirement.java
@@ -66,6 +66,8 @@ public final class Requirement {
 			case consumedBonemeals:
 				return value >= 0;
 			case hasActorCondition:
+			case factionScore:
+			case factionScoreEquals:
 				return requireID != null;
 			case inventoryKeep:
 			case inventoryRemove:
@@ -86,8 +88,6 @@ public final class Requirement {
 				return chance != null;
 			case timerElapsed:
 				return requireID != null && value >= 0;
-			case factionScore:
-			case factionScoreEquals:
 			default:
 				return false;
 		}


### PR DESCRIPTION
This request fixes `factionScore` and `factionScoreEquals` requirements. They broke in version 0.7.10, but this feature is not used seriously yet.