### PR TITLE
Update quest log text to first person

### DIFF
--- a/AndorsTrail/res/raw/questlist_arulir_mountain.json
+++ b/AndorsTrail/res/raw/questlist_arulir_mountain.json
@@ -105,7 +105,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"In a clearing, you met Tjure, who desperately asked for your help. He had once found a mermaid asleep on the beach at the river. The colorful tail attracted him so much that he pulled out a dazzling scale and ran away."
+                "logText":"In a remote clearing, I met a man named Tjure who desperately asked for my help. He had once found a mermaid asleep on the beach at the river. The colorful tail attracted him so much that he pulled out a dazzling scale and ran away."
             },
             {
                 "progress":20,
@@ -117,17 +117,17 @@
             },
             {
                 "progress":90,
-                "logText":"You decided not to help Tjure.",
+                "logText":"I've decided not to help Tjure.",
                 "rewardExperience":500,
                 "finishesQuest":1
             },
             {
                 "progress":100,
-                "logText":"As soon as you held the scale in your hands, a great sluggishness and dispair came over you."
+                "logText":"I offered to buy the scale from Tjure to free him of his curse. As soon as I did, I felt a wave of sluggishness and despair."
             },
             {
                 "progress":200,
-                "logText":"You put the scale on the mark on the ground."
+                "logText":"I placed the scale on the mark on the ground near the river that Tjure described."
             },
             {
                 "progress":210,
@@ -137,7 +137,7 @@
             },
             {
                 "progress":220,
-                "logText":"You found a heavy bag of gold."
+                "logText":"I found a heavy bag of gold."
             }
         ]
     },

--- a/AndorsTrail/res/raw/questlist_brimhaven.json
+++ b/AndorsTrail/res/raw/questlist_brimhaven.json
@@ -6,7 +6,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"You found two not very bright brothers in a cellar of their house. They seemed to be talking about some sinister plan."
+                "logText":"I found two not very bright brothers in a cellar of their house. They seemed to be talking about some sinister plan."
             },
             {
                 "progress":20,
@@ -14,19 +14,19 @@
             },
             {
                 "progress":30,
-                "logText":"They asked you to help them."
+                "logText":"They asked me to help them."
             },
             {
                 "progress":50,
-                "logText":"You agreed to destroy the dam for them."
+                "logText":"I have agreed to destroy the dam for them."
             },
             {
                 "progress":52,
-                "logText":"They gave you a hand axe that could weaken the dam in a vulnerable place."
+                "logText":"The brothers gave me a hand axe that could weaken the dam in a vulnerable place."
             },
             {
                 "progress":54,
-                "logText":"You found the weak spot in the dam and started hacking at the wood.",
+                "logText":"I found the weak spot in the dam and started hacking at the wood.",
                 "rewardExperience":500
             },
             {
@@ -35,11 +35,11 @@
             },
             {
                 "progress":70,
-                "logText":"You refused to destroy the dam for them."
+                "logText":"I refused to destroy the dam for the brothers."
             },
             {
                 "progress":72,
-                "logText":"Given what you knew, you were not allowed to leave. The two brothers attacked you."
+                "logText":"Given what I overheard, I was not allowed to leave. The two brothers attacked me."
             },
             {
                 "progress":80,
@@ -47,11 +47,11 @@
             },
             {
                 "progress":100,
-                "logText":"You were not allowed to leave the city until it was investigated who destroyed the dam."
+                "logText":"The Brimhaven guards have informed me that I may not leave the city until they have investigated who destroyed the dam."
             },
             {
                 "progress":110,
-                "logText":"You promised to track down the real perpetrators. However, you should not leave the city."
+                "logText":"I have promised to track down the real perpetrators. However, I still cannot not leave the city."
             },
             {
                 "progress":120,
@@ -67,7 +67,7 @@
             },
             {
                 "progress":200,
-                "logText":"You gave the letters as a piece of evidence to the captain of the guard. Now it is up to them to deal with the rich man. ",
+                "logText":"I gave the letters as a piece of evidence to the captain of the guard. Now it is up to them to deal with the rich man.",
                 "rewardExperience":1000,
                 "finishesQuest":1
             }
@@ -84,27 +84,27 @@
             },
             {
                 "progress":10,
-                "logText":"Stebbarik was ill at home in bed. He could not work and feared that he would lose his job. Because of his high debts, he feared that Gnossath would then take his house away.\nYou offered to do the work for Stebbarik."
+                "logText":"Stebbarik was ill at home in bed. He could not work and feared that he would lose his job. Because of his high debts, he feared that Gnossath would then take his house away.\nI have offered to do the work for Stebbarik."
             },
             {
                 "progress":30,
-                "logText":"Gnossath told you to carry 25 heavy boulders from the stock to the dam."
+                "logText":"Gnossath has asked me to carry 25 heavy boulders from the stock to the dam."
             },
             {
                 "progress":40,
-                "logText":"You carried the first boulder to the dam."
+                "logText":"I have carried the first boulder to the dam."
             },
             {
                 "progress":41,
-                "logText":"You have carried 5 boulders to the dam."
+                "logText":"I have carried 5 boulders to the dam."
             },
             {
                 "progress":42,
-                "logText":"You have moved 10 boulders."
+                "logText":"I have moved 10 boulders."
             },
             {
                 "progress":43,
-                "logText":"You have moved 15 boulders. You are getting tired!"
+                "logText":"I have moved 15 boulders. This work is exhausting!"
             },
             {
                 "progress":44,
@@ -112,7 +112,7 @@
             },
             {
                 "progress":90,
-                "logText":"Finally - that was the last boulder! Gnossath was very pleased with your work.",
+                "logText":"Finally - that was the last boulder! Gnossath was very pleased with my work.",
                 "finishesQuest":1
             }
         ]
@@ -272,7 +272,7 @@
             },
             {
                 "progress":15,
-                "logText":"I denied to help Anaksi to find his sister, Juttarka."
+                "logText":"I denied to help Anakis to find his sister, Juttarka."
             },
             {
                 "progress":20,
@@ -301,7 +301,7 @@
             },
             {
                 "progress":77,
-                "logText":"Fangwurm told me that the Basilisk's blood has special properties. It can protect against damage if applied to the skin. Fresh, warm, Basilisk's blood might even be able to heal a person that has been turned to stone.  "
+                "logText":"Fangwurm told me that the Basilisk's blood has special properties. It can protect against damage if applied to the skin. Fresh, warm, Basilisk's blood might even be able to heal a person that has been turned to stone."
             },
             {
                 "progress":78,
@@ -309,7 +309,7 @@
             },
             {
                 "progress":79,
-                "logText":"I should search the other rooms in this cave for a mirror that I can use to protect me from the glance of the Basilisk. "
+                "logText":"I should search the other rooms in this cave for a mirror that I can use to protect me from the glance of the Basilisk."
             },
             {
                 "progress":80,
@@ -557,31 +557,31 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"You thought it would be a good idea to give a necklace to your father, in your family colors of red, green, and white. "
+                "logText":"I have decided to give a necklace to my father Mikhail, in our family colors of red, green, and white."
             },
             {
                 "progress":20,
-                "logText":"You bought a necklace."
+                "logText":"I have purchased a necklace."
             },
             {
                 "progress":30,
-                "logText":"Your father didn't want to take the necklace. He was angry because you didn't focus on finding your brother Andor. "
+                "logText":"Mikhail didn't want to take the necklace. He was angry because I didn't focus on finding Andor."
             },
             {
                 "progress":40,
-                "logText":"Your father didn't seem very happy with the cheap necklace.",
+                "logText":"My father didn't seem very happy with the cheap necklace.",
                 "rewardExperience":50,
                 "finishesQuest":1
             },
             {
                 "progress":50,
-                "logText":"Your father was very happy with the nice necklace.",
+                "logText":"My father was very happy with the nice necklace.",
                 "rewardExperience":500,
                 "finishesQuest":1
             },
             {
                 "progress":60,
-                "logText":"Your father was disappointed with your pretentious necklace.",
+                "logText":"My father was disappointed with the pretentious necklace I bought.",
                 "rewardExperience":50,
                 "finishesQuest":1
             }

--- a/AndorsTrail/res/raw/questlist_brimhaven2.json
+++ b/AndorsTrail/res/raw/questlist_brimhaven2.json
@@ -6,15 +6,15 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"You entered a classroom in Brimhaven's school. The teacher told you to sit down."
+                "logText":"I entered a classroom in Brimhaven's school. The teacher told me to sit down."
             },
             {
                 "progress":12,
-                "logText":"You noticed an evil-looking statue in a corner. Who on earth puts such an ugly, hideous thing in a school?"
+                "logText":"I noticed an evil-looking statue in a corner. Who on earth puts such an ugly, hideous thing in a school?"
             },
             {
                 "progress":20,
-                "logText":"You found a free place next to Golin."
+                "logText":"I found a free place next to a student named Golin."
             },
             {
                 "progress":30,
@@ -30,78 +30,78 @@
             },
             {
                 "progress":60,
-                "logText":"You should look for a dueling partner."
+                "logText":"I should look for a dueling partner."
             },
             {
                 "progress":100,
-                "logText":"You started a fight with Golin."
+                "logText":"I started a fight with Golin."
             },
             {
                 "progress":102,
-                "logText":"You started a fight with Golin and killed him."
+                "logText":"I started a fight with Golin and killed him."
             },
             {
                 "progress":104,
-                "logText":"You started a fight with Golin, but you broke off the duel. Very good.",
+                "logText":"I started a fight with Golin, but I broke off the duel. Very good.",
                 "rewardExperience":500
             },
             {
                 "progress":110,
-                "logText":"You tried to fight a pupil, but they all ran away screaming."
+                "logText":"I tried to fight a pupil, but they all ran away screaming."
             },
             {
                 "progress":120,
-                "logText":"You started a fight with the teacher."
+                "logText":"I started a fight with the teacher."
             },
             {
                 "progress":122,
-                "logText":"You started a fight with the teacher and killed her.",
+                "logText":"I started a fight with the teacher and killed her.",
                 "rewardExperience":1000
             },
             {
                 "progress":124,
-                "logText":"You started a fight with the teacher, but you broke off the duel. Very good.",
+                "logText":"I started a fight with the teacher, but I broke off the duel. Very good.",
                 "rewardExperience":500
             },
             {
                 "progress":130,
-                "logText":"You feel the evil stare of the statue."
+                "logText":"I feel the evil stare of the statue."
             },
             {
                 "progress":150,
-                "logText":"The evil grinning statue suddenly grew to an incredible size and attacked you!"
+                "logText":"The evil grinning statue suddenly grew to an incredible size and attacked me!"
             },
             {
                 "progress":152,
-                "logText":"You killed the evil statue."
+                "logText":"I killed the evil statue."
             },
             {
                 "progress":200,
-                "logText":"The teacher thanked you for saving him. School is over for you. You could go to the general store and get a cake for good performance.",
+                "logText":"The teacher thanked me for saving him. School is over for me. I can go to the general store and get a cake for good performance.",
                 "rewardExperience":5000,
                 "finishesQuest":1
             },
             {
                 "progress":210,
-                "logText":"You cheated during the duel. The teacher noticed it and banned you from the school.",
+                "logText":"I cheated during the duel. The teacher noticed it and banned me from the school.",
                 "rewardExperience":500,
                 "finishesQuest":1
             },
             {
                 "progress":220,
-                "logText":"The teacher was very satisfied with your performance in the duel. School is over for you. You could go to the general store and get a cake for good performance.",
+                "logText":"The teacher was very satisfied with my performance in the duel. School is over for me. I can go to the general store and get a cake for good performance.",
                 "rewardExperience":1000,
                 "finishesQuest":1
             },
             {
                 "progress":230,
-                "logText":"The teacher sent you away, because you killed Golin in the duel.",
+                "logText":"The teacher sent me away, because I killed Golin in the duel.",
                 "rewardExperience":500,
                 "finishesQuest":1
             },
             {
                 "progress":240,
-                "logText":"Golin was horrified by your murder of the teacher and attacked you to avenge her.",
+                "logText":"Golin was horrified by my murder of the teacher and attacked me to avenge her.",
                 "rewardExperience":500,
                 "finishesQuest":1
             }
@@ -114,47 +114,47 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Facutloni asked you to help him check the storage. You should check if there is a pair of every item."
+                "logText":"Facutloni asked me to help him check the storage. I should check if there is a pair of every item."
             },
             {
                 "progress":100,
-                "logText":"You have found a pair of crystal globes."
+                "logText":"I have found a pair of crystal globes."
             },
             {
                 "progress":101,
-                "logText":"You have found a pair of plush pillows."
+                "logText":"I have found a pair of plush pillows."
             },
             {
                 "progress":102,
-                "logText":"You have found a pair of lyras."
+                "logText":"I have found a pair of lyras."
             },
             {
                 "progress":103,
-                "logText":"You have found a pair of boots."
+                "logText":"I have found a pair of boots."
             },
             {
                 "progress":104,
-                "logText":"You have found a pair of chandeliers."
+                "logText":"I have found a pair of chandeliers."
             },
             {
                 "progress":105,
-                "logText":"You have found a pair of mysterious green somethings."
+                "logText":"I have found a pair of mysterious green somethings."
             },
             {
                 "progress":106,
-                "logText":"You have found a pair of old, worn capes."
+                "logText":"I have found a pair of old, worn capes."
             },
             {
                 "progress":107,
-                "logText":"You have found a pair of pretty porcelain figures."
+                "logText":"I have found a pair of pretty porcelain figures."
             },
             {
                 "progress":108,
-                "logText":"You have found a pair of striped hammers."
+                "logText":"I have found a pair of striped hammers."
             },
             {
                 "progress":109,
-                "logText":"You have found a pair of dusty old books."
+                "logText":"I have found a pair of dusty old books."
             },
             {
                 "progress":900,

--- a/AndorsTrail/res/raw/questlist_burhczyd.json
+++ b/AndorsTrail/res/raw/questlist_burhczyd.json
@@ -6,27 +6,27 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"You met Burhczyd afgz Dtaloumiye, a likable young man, in a tavern. He wanted to see the world and followed your advice to travel as a trader from city to city.",
+                "logText":"I met Burhczyd afgz Dtaloumiye, a likable young man, in a tavern. He wanted to see the world and followed my advice to travel as a trader from city to city.",
                 "rewardExperience":20
             },
             {
                 "progress":20,
-                "logText":"In another tavern you met Burhczyd again. He never got any customers, because he had named his company 'Burhczyd afgz Dtaloumiye - Transports'. You told him to find an easier name.",
+                "logText":"In another tavern I met Burhczyd again. He never got any customers, because he had named his company 'Burhczyd afgz Dtaloumiye - Transports'. I told him to find an easier name.",
                 "rewardExperience":50
             },
             {
                 "progress":30,
-                "logText":"You saw Burhczyd in a tavern, but he still did not have any customers. You told him that 'B.A.D. Transports' was not a good idea either.",
+                "logText":"I saw Burhczyd in a tavern, but he still did not have any customers. I told him that 'B.A.D. Transports' was not a good idea either.",
                 "rewardExperience":100
             },
             {
                 "progress":40,
-                "logText":"Another place, another tavern, Burhczyd again sitting there. He did get a shipment from Remgard of almost fresh fish, but nobody wanted to buy it. You bought the entire cargo and got it disposed of.",
+                "logText":"Another place, another tavern, Burhczyd again sitting there. He did get a shipment from Remgard of almost fresh fish, but nobody wanted to buy it. I bought the entire cargo and disposed of it.",
                 "rewardExperience":200
             },
             {
                 "progress":50,
-                "logText":"What a surprise - you met Burhczyd again in a tavern. He told you that he finally sold something successfully - his cart. The fool, how will he earn money now?",
+                "logText":"What a surprise - I met Burhczyd again in a tavern. He told me that he finally sold something successfully - his cart. The fool, how will he earn money now?",
                 "rewardExperience":500
             },
             {
@@ -36,22 +36,22 @@
             },
             {
                 "progress":70,
-                "logText":"You found Burhczyd collapsed at a table in the tavern, his lute lying in front of him. The landlord forbade him to play his lovely music, because then all the guests forgot to drink.",
+                "logText":"I found Burhczyd collapsed at a table in the tavern, his lute lying in front of him. The landlord forbade him to play his lovely music, because then all the guests forgot to drink.",
                 "rewardExperience":2000
             },
             {
                 "progress":80,
-                "logText":"Again you met Burhczyd in a tavern. He told you that he had become a master thief.",
+                "logText":"Again I met Burhczyd in a tavern. He told me that he had become a master thief.",
                 "rewardExperience":5000
             },
             {
                 "progress":90,
-                "logText":"When you met Burhczyd again, he gave you some of your things back.",
+                "logText":"When I met Burhczyd again, he remorsefully informed me that he had stolen from me. He returned my possessions.",
                 "rewardExperience":10000
             },
             {
                 "progress":100,
-                "logText":"You've talked with a Knight of Elythom who happened to be an old acquaintance - Burhczyd. He had to hide from the Elythom, because he had 'borrowed' something of value from their leader.",
+                "logText":"I've talked with a Knight of Elythom who happened to be an old acquaintance - Burhczyd. He had to hide from the Elythom, because he had 'borrowed' something of value from their leader.",
                 "rewardExperience":20000
             },
             {

--- a/AndorsTrail/res/raw/questlist_guynmart.json
+++ b/AndorsTrail/res/raw/questlist_guynmart.json
@@ -183,7 +183,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"Little Stuephant was crying because he lost his marbles. You told him you would find them for him."
+                "logText":"Little Stuephant was crying because he lost his marbles. I told him that I would find them for him."
             },
             {
                 "progress":21,
@@ -232,7 +232,7 @@
             },
             {
                 "progress":30,
-                "logText":"He would be even happier if the cheese was cheddar from Charwood.\nYou can only get the cheddar there if you explicitly ask for it."
+                "logText":"He would be even happier if the cheese was cheddar from Charwood.\nHe mentioned that I can only get the cheddar there if I explicitly ask for it."
             },
             {
                 "progress":90,

--- a/AndorsTrail/res/raw/questlist_stoutford_combined.json
+++ b/AndorsTrail/res/raw/questlist_stoutford_combined.json
@@ -589,7 +589,7 @@
         "stages":[
             {
                 "progress":10,
-                "logText":"The little daughter of Odirath the armorer has been missing for several days now. You offered to help search for her."
+                "logText":"The little daughter of Odirath the armorer has been missing for several days now. I have offered to help search for her."
             },
             {
                 "progress":20,
@@ -597,7 +597,7 @@
             },
             {
                 "progress":30,
-                "logText":"You offered Gyra to lead her back home safely."
+                "logText":"I have offered to lead Gyra back home safely."
             },
             {
                 "progress":40,
@@ -605,15 +605,15 @@
             },
             {
                 "progress":50,
-                "logText":"You found the helmet."
+                "logText":"I found Lord Berbane's helmet."
             },
             {
                 "progress":60,
-                "logText":"Once back in Stoutford Gyra knew the way and ran to her father Odirath."
+                "logText":"Once back in Stoutford, Gyra knew the way and ran to her father Odirath."
             },
             {
                 "progress":70,
-                "logText":"Odirath thanks you many thousand times.",
+                "logText":"Odirath thanks me many thousand times for bringing Gyra home safely.",
                 "rewardExperience":2300
             },
             {
@@ -622,7 +622,7 @@
             },
             {
                 "progress":92,
-                "logText":"Lord Berbane took his helmet. But somehow that does not really satisfy you."
+                "logText":"Lord Berbane took his helmet. Somehow, this does not really satisfy me."
             },
             {
                 "progress":99,
@@ -630,7 +630,7 @@
             },
             {
                 "progress":170,
-                "logText":"Odirath thanks you many thousand times.",
+                "logText":"Odirath thanks me many thousand times for bringing Gyra home safely.",
                 "rewardExperience":2500,
                 "finishesQuest":1
             },


### PR DESCRIPTION
User-visible logText for quest entries should be written in first person (as indicated here: https://andorstrail.com/wiki/test/andors_trail_wiki/developer_section/quests_conversation.html).

Most quests follow this guideline, but a small number have messages that do not:

- The silver scale (mermaid_scale)
- Much water (brv_flood)
- Work for debts (brv_employee)
- Honor your parents (brv_present)
- Lessons learned (brv_school2)
- Inventory (brv_wh)
- Young merchant (quest_burhczyd)
- Marble hunting (guynmart_marbles)
- Rare delicacies (guynmart_wise)
- Lost girl looking for lost things (stn_quest_gyra)

This PR corrects the logText to be consistently first person, along with a few minor grammar and spelling fixes.