### PR TITLE
fix

### DIFF
--- a/AndorsTrail/res/raw/questlist_graveyard1.json
+++ b/AndorsTrail/res/raw/questlist_graveyard1.json
@@ -97,7 +97,7 @@
             },
             {
                 "progress":35,
-                "logText":"I promised Cithurn I would investigate the source of the monster invasion in the forest. I will have to pass through the forest to access an entrance to a cave northeast of Cithurn's home."
+                "logText":"I promised Cithurn I would investigate the source of the monster invasion in the forest. I will have to pass through the forest to access an entrance to a cave east of Cithurn's home."
             },
             {
                 "progress":40,


### PR DESCRIPTION
Fix the direction from northeast to east, because the cave entrance is on the east an also Cithurn originay sed:
andors-trail-master\AndorsTrail\res\raw\conversationlist_graveyard1.json
"Thank you. You will have to pass through the forest to reach an opening to the cave where you can enter. The opening is roughly east of my home."