### PR TITLE
Rebuild world map

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/WorldSetup.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/WorldSetup.java
@@ -1,5 +1,6 @@
 package com.gpl.rpg.AndorsTrail;
 
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 
 import android.content.Context;
@@ -8,9 +9,11 @@ import android.os.AsyncTask;
 
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
+import com.gpl.rpg.AndorsTrail.controller.WorldMapController;
 import com.gpl.rpg.AndorsTrail.model.ModelContainer;
 import com.gpl.rpg.AndorsTrail.resource.ResourceLoader;
 import com.gpl.rpg.AndorsTrail.savegames.Savegames;
+import com.gpl.rpg.AndorsTrail.util.L;
 
 public final class WorldSetup {
 
@@ -152,6 +155,13 @@ public final class WorldSetup {
 	private void createNewWorld() {
 		Context ctx = androidContext.get();
 		world.model = new ModelContainer(newHeroStartLives, newHeroUnlimitedSaves);
+
+		try {
+			WorldMapController.initializeWorldMap(world);
+		} catch (IOException e) {
+			L.log("Error initializing worldmap: " + e.toString());
+		}
+
 		world.model.player.initializeNewPlayer(world.dropLists, newHeroName, newHeroIcon);
 
 		controllers.actorStatsController.recalculatePlayerStats(world.model.player);

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/WorldMapController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/WorldMapController.java
@@ -26,6 +26,7 @@ import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.model.map.LayeredTileMap;
 import com.gpl.rpg.AndorsTrail.model.map.MapLayer;
 import com.gpl.rpg.AndorsTrail.model.map.PredefinedMap;
+import com.gpl.rpg.AndorsTrail.model.map.TMXMapTranslator;
 import com.gpl.rpg.AndorsTrail.model.map.WorldMapSegment;
 import com.gpl.rpg.AndorsTrail.model.map.WorldMapSegment.NamedWorldMapArea;
 import com.gpl.rpg.AndorsTrail.model.map.WorldMapSegment.WorldMapSegmentMap;
@@ -314,5 +315,41 @@ public final class WorldMapController {
 		context.startActivity(intent);
 
 		return true;
+	}
+
+	public static void initializeWorldMap(WorldContext world) throws IOException {
+		ensureWorldmapDirectoryExists();
+		File dir = getWorldmapDirectory();
+
+		File idFile = new File(dir, world.model.player.id);
+		if (!idFile.exists()) idFile.createNewFile();
+	}
+
+	public static void populateWorldMap(WorldContext world, Resources res) throws IOException {
+		ensureWorldmapDirectoryExists();
+		File dir = getWorldmapDirectory();
+
+		File idFile = new File(dir, world.model.player.id);
+		if (idFile.exists()) return;
+		idFile.createNewFile();
+
+		for (PredefinedMap map : world.maps.getAllMaps()) {
+			if (!map.visited) continue;
+
+			String worldMapSegmentName = world.maps.getWorldMapSegmentNameForMap(map.name);
+			if (worldMapSegmentName == null) continue;
+
+			boolean mapFileExists = fileForMapExists(map);
+			File worldMapFile = getCombinedWorldMapFile(worldMapSegmentName);
+			if (mapFileExists && worldMapFile.exists()) continue;
+
+			LayeredTileMap mapTiles = TMXMapTranslator.readLayeredTileMap(res, world.tileManager.tileCache, map);
+			mapTiles.changeColorFilter(map.currentColorFilter);
+			TileCollection cachedTiles = world.tileManager.loadTilesFor(map, mapTiles, world, res);
+
+			MapRenderer renderer = new MapRenderer(world, map, mapTiles, cachedTiles);
+			updateCachedBitmap(map, renderer);
+			updateWorldMapSegment(res, world, worldMapSegmentName);
+		}
 	}
 }

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/ModelContainer.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/ModelContainer.java
@@ -7,9 +7,7 @@ import java.io.IOException;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.model.actor.Player;
-import com.gpl.rpg.AndorsTrail.model.map.LayeredTileMap;
 import com.gpl.rpg.AndorsTrail.model.map.PredefinedMap;
-import com.gpl.rpg.AndorsTrail.resource.tiles.TileCollection;
 
 public final class ModelContainer {
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
@@ -29,6 +29,7 @@ import com.gpl.rpg.AndorsTrail.R;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.controller.Constants;
+import com.gpl.rpg.AndorsTrail.controller.WorldMapController;
 import com.gpl.rpg.AndorsTrail.model.ModelContainer;
 import com.gpl.rpg.AndorsTrail.resource.tiles.TileManager;
 import com.gpl.rpg.AndorsTrail.util.L;
@@ -219,6 +220,7 @@ public final class Savegames {
 
 		world.maps.readFromParcel(src, world, controllers, header.fileversion);
 		world.model = new ModelContainer(src, world, controllers, header.fileversion);
+		WorldMapController.populateWorldMap(world, controllers.getResources());
 		src.close();
 		
 		if (header.fileversion < 45) {


### PR DESCRIPTION
This patch allows users to rebuild the world map, which is useful if you only have the savegame. The process takes some time if many files are missing. It is not executed for new games when the application is started without external storage permission, but this is a cosmetic bug.

Perhaps you should consider moving the world map to internal storage. Eventually, external storage should not be a requirement.