### PR TITLE
Prevent stray taps from accidentally cancelling loot windows

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/Dialogs.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/Dialogs.java
@@ -202,7 +202,8 @@ public final class Dialogs {
 				mainActivity.getResources().getDrawable(R.drawable.ui_icon_equipment), 
 				msg, 
 				combinedLoot.items.isEmpty() ? null : itemList, 
-						true);
+				true,
+				false);
 
 		itemList.setOnItemClickListener(new OnItemClickListener() {
 			@Override
@@ -255,7 +256,8 @@ public final class Dialogs {
 				mainActivity.getResources().getDrawable(R.drawable.ui_icon_combat),
 				mainActivity.getResources().getString(R.string.dialog_game_over_text),
 				null,
-				true);
+				true,
+				false);
 
 		CustomDialogFactory.addDismissButton(d, android.R.string.ok);
 


### PR DESCRIPTION
Per discussion on Discord #suggestions (@Omicronrg9 and @Rijackson), prevent taps outside of loot dialogs from closing them.

This also applies the same fix for the "Game Over" screen, which is also accidentally dismissable in the same way, despite being a rather significant event.