### PR TITLE
kill count stats by monster name instead of ID

### DIFF
--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -238,7 +238,7 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		controllers.actorStatsController.addActorAP(player, player.getSkillLevel(SkillCollection.SkillID.cleave) * SkillCollection.PER_SKILLPOINT_INCREASE_CLEAVE_AP);
 		controllers.actorStatsController.addActorHealth(player, player.getSkillLevel(SkillCollection.SkillID.eater) * SkillCollection.PER_SKILLPOINT_INCREASE_EATER_HEALTH);
 
-		world.model.statistics.addMonsterKill(killedMonster.getMonsterTypeID());
+		world.model.statistics.addMonsterKill(killedMonster.monsterType);
 		controllers.actorStatsController.addExperience(loot.exp);
 		world.model.combatLog.append(controllers.getResources().getString(R.string.dialog_monsterloot_gainedexp, loot.exp));
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
@@ -78,12 +78,12 @@ public final class GameStatistics {
 		return v;
 	}
 
-	public int getNumberOfKillsForMonsterName(String monsterName) {
+	/*public int getNumberOfKillsForMonsterName(String monsterName) {
 		Integer v = killedMonstersByName.get(monsterName);
 		if (v == null) return 0;
 		return v;
 	}
-
+*/
 	public String getTop5MostCommonlyKilledMonsters(WorldContext world, Resources res) {
 		if (killedMonstersByTypeID.isEmpty()) return null;
 		List<Entry<String, Integer>> entries = new ArrayList<Entry<String, Integer>>(killedMonstersByName.entrySet());

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
@@ -15,7 +15,6 @@ import android.content.res.Resources;
 
 import com.gpl.rpg.AndorsTrail.R;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
-import com.gpl.rpg.AndorsTrail.model.actor.Monster;
 import com.gpl.rpg.AndorsTrail.model.actor.MonsterType;
 import com.gpl.rpg.AndorsTrail.model.item.ItemType;
 import com.gpl.rpg.AndorsTrail.model.map.PredefinedMap;
@@ -23,9 +22,9 @@ import com.gpl.rpg.AndorsTrail.model.quest.Quest;
 
 public final class GameStatistics {
 	private int deaths = 0;
-	private final HashMap<String, Integer> killedMonsters = new HashMap<String, Integer>();
-	private final HashMap<String, Integer> usedItems = new HashMap<String, Integer>();
+	private final HashMap<String, Integer> killedMonstersByTypeID = new HashMap<String, Integer>();
 	private final HashMap<String, Integer> killedMonstersByName = new HashMap<String, Integer>();
+	private final HashMap<String, Integer> usedItems = new HashMap<String, Integer>();
 	private int spentGold = 0;
 	private boolean unlimitedSaves = true;
 	private int startLives = -1; // -1 --> unlimited
@@ -37,7 +36,7 @@ public final class GameStatistics {
 
 	public void addMonsterKill(MonsterType monsterType) {
 		// Track monster kills by type ID, for savegame file
-		killedMonsters.put(monsterType.id, killedMonsters.getOrDefault((monsterType.id), 0) + 1);
+		killedMonstersByTypeID.put(monsterType.id, killedMonstersByTypeID.getOrDefault((monsterType.id), 0) + 1);
 
 		// Also track by name, for statistics display (multiple IDs w/same name don't matter to player)
 		killedMonstersByName.put(monsterType.name, killedMonstersByName.getOrDefault(monsterType.name, 0) + 1);
@@ -74,7 +73,7 @@ public final class GameStatistics {
 	public boolean isDead() { return !hasUnlimitedLives() && getLivesLeft() < 1; }
 
 	public int getNumberOfKillsForMonsterType(String monsterTypeID) {
-		Integer v = killedMonsters.get(monsterTypeID);
+		Integer v = killedMonstersByTypeID.get(monsterTypeID);
 		if (v == null) return 0;
 		return v;
 	}
@@ -86,7 +85,7 @@ public final class GameStatistics {
 	}
 
 	public String getTop5MostCommonlyKilledMonsters(WorldContext world, Resources res) {
-		if (killedMonsters.isEmpty()) return null;
+		if (killedMonstersByTypeID.isEmpty()) return null;
 		List<Entry<String, Integer>> entries = new ArrayList<Entry<String, Integer>>(killedMonstersByName.entrySet());
 		Collections.sort(entries, descendingValueComparator);
 		StringBuilder sb = new StringBuilder(100);
@@ -99,9 +98,9 @@ public final class GameStatistics {
 	}
 
 	public String getMostPowerfulKilledMonster(WorldContext world) {
-		if (killedMonsters.isEmpty()) return null;
-		HashMap<String, Integer> expPerMonsterType = new HashMap<String, Integer>(killedMonsters.size());
-		for (String monsterTypeID : killedMonsters.keySet()) {
+		if (killedMonstersByTypeID.isEmpty()) return null;
+		HashMap<String, Integer> expPerMonsterType = new HashMap<String, Integer>(killedMonstersByTypeID.size());
+		for (String monsterTypeID : killedMonstersByTypeID.keySet()) {
 			MonsterType t = world.monsterTypes.getMonsterType(monsterTypeID);
 			expPerMonsterType.put(monsterTypeID, t != null ? t.exp : 0);
 		}
@@ -157,7 +156,7 @@ public final class GameStatistics {
 
 	public int getNumberOfKilledMonsters() {
 		int result = 0;
-		for (int v : killedMonsters.values()) result += v;
+		for (int v : killedMonstersByTypeID.values()) result += v;
 		return result;
 	}
 
@@ -182,7 +181,7 @@ public final class GameStatistics {
 				if (type == null) continue;
 				id = type.id;
 			}
-			this.killedMonsters.put(id, value);
+			this.killedMonstersByTypeID.put(id, value);
 
 			// Also track by name, for statistics display (multiple IDs w/same name don't matter to player)
 			MonsterType t = world.monsterTypes.getMonsterType(id);
@@ -208,7 +207,7 @@ public final class GameStatistics {
 
 	public void writeToParcel(DataOutputStream dest) throws IOException {
 		dest.writeInt(deaths);
-		Set<Entry<String, Integer> > set = killedMonsters.entrySet();
+		Set<Entry<String, Integer> > set = killedMonstersByTypeID.entrySet();
 		dest.writeInt(set.size());
 		for (Entry<String, Integer> e : set) {
 			dest.writeUTF(e.getKey());

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/actor/Monster.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/actor/Monster.java
@@ -26,7 +26,7 @@ public final class Monster extends Actor {
 	private boolean forceAggressive = false;
 	private ItemContainer shopItems = null;
 
-	private final MonsterType monsterType;
+	public final MonsterType monsterType;
 	public final MonsterSpawnArea area;
 
 	public Monster(MonsterType monsterType, MonsterSpawnArea area) {


### PR DESCRIPTION
This patch fixes the "Most commonly killed monsters" display to prevent duplicate entries where more than one MonsterType has the same display name.  It adds an additional hashmap to count on a per-name basis, while leaving the existing counter alone so that savegame files aren't affected.  I tested it on the two versions of the "Iqhan chaos master" (red and purple).

This is both my first experience tweaking Java code and my first attempt to contribute to AT, so please let me know if I went to far in changing existing classes or refactoring existing code for clarity that should have been left alone - I could have minimized existing code changes by calculating on display only, but that would involve re-allocating an object each time and that's discouraged per the wiki.  I think this approach is cleaner and will better support another patch I'm working on (adding kills to monster info display).

In particular, I'm not sure how the team feels about making Monster.monsterType public, but it enables playerKilledMonster() to pass the MonsterType object directly to the GameStatistics.addMonsterKill method (instead of just the string ID), which allows it to get the both the monster ID and name without an awkward double-lookup that would have required adding an argument to pass the WorldContext anyway.  I know the extra cycles are insignificant these days, but trying to keep it efficient is a hard habit to break.  Would it be better to add a Monster.getMonsterType() read-only property rather than simply making the variable public?

A note on potential wierdness due to this patch - I wouldn't go so far as to call it a bug.  Because monster names are sourced from translations, it's possible that some monsters share the same name only in certain languages.  This could potentially cause confusion if the kill counts change when the game language preference is changed.

Finally, one other potential concern.  There is a killedMonster parameter in ConversationController.canFulfillRequirement that looks at kills on a per-monsterType basis.  I haven't checked to see exactly how this is used, but it could potentially be confusing if the player sees a body count in one place (based on kills per monster name) and can't complete some conversation item based  on a unique version of that monster.  I don't think I've seen any actual gameplay situations where this would be a problem, though (i.e., a quest character saying "come back after you've killed kill 50 purple Iqhan chaos masters.")