### PR TITLE
Monsterstatus killcount

### DIFF
--- a/AndorsTrail/res/layout/monsterinfo.xml
+++ b/AndorsTrail/res/layout/monsterinfo.xml
@@ -67,6 +67,11 @@
                 </TableRow>
 
                 <include layout="@layout/traitsinfoview" />
+
+                <TableRow android:id="@+id/monsterinfo_killcount_row">
+                    <TextView style="@style/traitsinfo_label" android:text="Previous kills:" />
+                    <TextView android:id="@+id/monsterinfo_killcount" />
+                </TableRow>
             </TableLayout>
 
             <com.gpl.rpg.AndorsTrail.view.ItemEffectsView

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -769,4 +769,9 @@ Items made of cloth are not considered as being armor." </string>
 	<string name="preferences_movement_dpad_transparency_60_pct">60%</string>
 	<string name="preferences_movement_dpad_transparency_70_pct">70%</string>
 
+	<!-- =========================================== -->
+	<!-- unreleased / proposed -->
+
+	<string name="monsterinfo_killcount">Previous kills</string>
+
 </resources>

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MonsterInfoActivity.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/activity/MonsterInfoActivity.java
@@ -31,6 +31,7 @@ public final class MonsterInfoActivity extends AndorsTrailBaseActivity {
 	private RangeBar hp;
 	private ViewGroup monsterinfo_container;
 	private TextView monsterinfo_max_ap;
+	private TextView monsterinfo_killcount;
 
 
 	@Override
@@ -48,6 +49,7 @@ public final class MonsterInfoActivity extends AndorsTrailBaseActivity {
 		monsterinfo_title = (TextView) findViewById(R.id.monsterinfo_title);
 		monsterinfo_difficulty = (TextView) findViewById(R.id.monsterinfo_difficulty);
 		monsterinfo_max_ap = (TextView) findViewById(R.id.monsterinfo_max_ap);
+		monsterinfo_killcount = (TextView) findViewById(R.id.monsterinfo_killcount);
 
 		Button b = (Button) findViewById(R.id.monsterinfo_close);
 		b.setOnClickListener(new OnClickListener() {
@@ -95,6 +97,7 @@ public final class MonsterInfoActivity extends AndorsTrailBaseActivity {
 				false);
 		hp.update(monster.getMaxHP(), monster.getCurrentHP());
 		monsterinfo_max_ap.setText(Integer.toString(monster.getMaxAP()));
+		monsterinfo_killcount.setText(Integer.toString(world.model.statistics.getNumberOfKillsForMonsterName(monster.getName()) ));
 	}
 
 	public static int getMonsterDifficultyResource(ControllerContext controllerContext, Monster monster) {

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -238,7 +238,7 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		controllers.actorStatsController.addActorAP(player, player.getSkillLevel(SkillCollection.SkillID.cleave) * SkillCollection.PER_SKILLPOINT_INCREASE_CLEAVE_AP);
 		controllers.actorStatsController.addActorHealth(player, player.getSkillLevel(SkillCollection.SkillID.eater) * SkillCollection.PER_SKILLPOINT_INCREASE_EATER_HEALTH);
 
-		world.model.statistics.addMonsterKill(killedMonster.getMonsterTypeID());
+		world.model.statistics.addMonsterKill(killedMonster.monsterType);
 		controllers.actorStatsController.addExperience(loot.exp);
 		world.model.combatLog.append(controllers.getResources().getString(R.string.dialog_monsterloot_gainedexp, loot.exp));
 

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
@@ -78,12 +78,12 @@ public final class GameStatistics {
 		return v;
 	}
 
-	public int getNumberOfKillsForMonsterName(String monsterName) {
+	/*public int getNumberOfKillsForMonsterName(String monsterName) {
 		Integer v = killedMonstersByName.get(monsterName);
 		if (v == null) return 0;
 		return v;
 	}
-
+*/
 	public String getTop5MostCommonlyKilledMonsters(WorldContext world, Resources res) {
 		if (killedMonstersByTypeID.isEmpty()) return null;
 		List<Entry<String, Integer>> entries = new ArrayList<Entry<String, Integer>>(killedMonstersByName.entrySet());

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
@@ -78,12 +78,12 @@ public final class GameStatistics {
 		return v;
 	}
 
-	/*public int getNumberOfKillsForMonsterName(String monsterName) {
+	public int getNumberOfKillsForMonsterName(String monsterName) {
 		Integer v = killedMonstersByName.get(monsterName);
 		if (v == null) return 0;
 		return v;
 	}
-*/
+
 	public String getTop5MostCommonlyKilledMonsters(WorldContext world, Resources res) {
 		if (killedMonstersByTypeID.isEmpty()) return null;
 		List<Entry<String, Integer>> entries = new ArrayList<Entry<String, Integer>>(killedMonstersByName.entrySet());

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/GameStatistics.java
@@ -15,7 +15,6 @@ import android.content.res.Resources;
 
 import com.gpl.rpg.AndorsTrail.R;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
-import com.gpl.rpg.AndorsTrail.model.actor.Monster;
 import com.gpl.rpg.AndorsTrail.model.actor.MonsterType;
 import com.gpl.rpg.AndorsTrail.model.item.ItemType;
 import com.gpl.rpg.AndorsTrail.model.map.PredefinedMap;
@@ -23,9 +22,9 @@ import com.gpl.rpg.AndorsTrail.model.quest.Quest;
 
 public final class GameStatistics {
 	private int deaths = 0;
-	private final HashMap<String, Integer> killedMonsters = new HashMap<String, Integer>();
-	private final HashMap<String, Integer> usedItems = new HashMap<String, Integer>();
+	private final HashMap<String, Integer> killedMonstersByTypeID = new HashMap<String, Integer>();
 	private final HashMap<String, Integer> killedMonstersByName = new HashMap<String, Integer>();
+	private final HashMap<String, Integer> usedItems = new HashMap<String, Integer>();
 	private int spentGold = 0;
 	private boolean unlimitedSaves = true;
 	private int startLives = -1; // -1 --> unlimited
@@ -37,7 +36,7 @@ public final class GameStatistics {
 
 	public void addMonsterKill(MonsterType monsterType) {
 		// Track monster kills by type ID, for savegame file
-		killedMonsters.put(monsterType.id, killedMonsters.getOrDefault((monsterType.id), 0) + 1);
+		killedMonstersByTypeID.put(monsterType.id, killedMonstersByTypeID.getOrDefault((monsterType.id), 0) + 1);
 
 		// Also track by name, for statistics display (multiple IDs w/same name don't matter to player)
 		killedMonstersByName.put(monsterType.name, killedMonstersByName.getOrDefault(monsterType.name, 0) + 1);
@@ -74,7 +73,7 @@ public final class GameStatistics {
 	public boolean isDead() { return !hasUnlimitedLives() && getLivesLeft() < 1; }
 
 	public int getNumberOfKillsForMonsterType(String monsterTypeID) {
-		Integer v = killedMonsters.get(monsterTypeID);
+		Integer v = killedMonstersByTypeID.get(monsterTypeID);
 		if (v == null) return 0;
 		return v;
 	}
@@ -86,7 +85,7 @@ public final class GameStatistics {
 	}
 
 	public String getTop5MostCommonlyKilledMonsters(WorldContext world, Resources res) {
-		if (killedMonsters.isEmpty()) return null;
+		if (killedMonstersByTypeID.isEmpty()) return null;
 		List<Entry<String, Integer>> entries = new ArrayList<Entry<String, Integer>>(killedMonstersByName.entrySet());
 		Collections.sort(entries, descendingValueComparator);
 		StringBuilder sb = new StringBuilder(100);
@@ -99,9 +98,9 @@ public final class GameStatistics {
 	}
 
 	public String getMostPowerfulKilledMonster(WorldContext world) {
-		if (killedMonsters.isEmpty()) return null;
-		HashMap<String, Integer> expPerMonsterType = new HashMap<String, Integer>(killedMonsters.size());
-		for (String monsterTypeID : killedMonsters.keySet()) {
+		if (killedMonstersByTypeID.isEmpty()) return null;
+		HashMap<String, Integer> expPerMonsterType = new HashMap<String, Integer>(killedMonstersByTypeID.size());
+		for (String monsterTypeID : killedMonstersByTypeID.keySet()) {
 			MonsterType t = world.monsterTypes.getMonsterType(monsterTypeID);
 			expPerMonsterType.put(monsterTypeID, t != null ? t.exp : 0);
 		}
@@ -157,7 +156,7 @@ public final class GameStatistics {
 
 	public int getNumberOfKilledMonsters() {
 		int result = 0;
-		for (int v : killedMonsters.values()) result += v;
+		for (int v : killedMonstersByTypeID.values()) result += v;
 		return result;
 	}
 
@@ -182,7 +181,7 @@ public final class GameStatistics {
 				if (type == null) continue;
 				id = type.id;
 			}
-			this.killedMonsters.put(id, value);
+			this.killedMonstersByTypeID.put(id, value);
 
 			// Also track by name, for statistics display (multiple IDs w/same name don't matter to player)
 			MonsterType t = world.monsterTypes.getMonsterType(id);
@@ -208,7 +207,7 @@ public final class GameStatistics {
 
 	public void writeToParcel(DataOutputStream dest) throws IOException {
 		dest.writeInt(deaths);
-		Set<Entry<String, Integer> > set = killedMonsters.entrySet();
+		Set<Entry<String, Integer> > set = killedMonstersByTypeID.entrySet();
 		dest.writeInt(set.size());
 		for (Entry<String, Integer> e : set) {
 			dest.writeUTF(e.getKey());

--- a/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/actor/Monster.java
+++ b/AndorsTrail/src/com/gpl/rpg/AndorsTrail/model/actor/Monster.java
@@ -26,7 +26,7 @@ public final class Monster extends Actor {
 	private boolean forceAggressive = false;
 	private ItemContainer shopItems = null;
 
-	private final MonsterType monsterType;
+	public final MonsterType monsterType;
 	public final MonsterSpawnArea area;
 
 	public Monster(MonsterType monsterType, MonsterSpawnArea area) {


### PR DESCRIPTION
Adds "Previous kills" to the monster info activity.  This is based on my previous killed_by_name branch and counts monsters based on having the same display name rather than same internal ID.  See comments to pull request for that patch.