### PR TITLE
Fixed the quest

### DIFF
--- a/AndorsTrail/res/raw/conversationlist_gorwath.json
+++ b/AndorsTrail/res/raw/conversationlist_gorwath.json
@@ -168,13 +168,6 @@
                 "nextPhraseID":"gorwath_letter_22"
             }
         ],
-        "rewards":[
-            {
-                "rewardType":"questProgress",
-                "rewardID":"postman",
-                "value":10
-            }
-        ]
     },
     {
         "id":"gorwath_letter_22",
@@ -219,7 +212,13 @@
                 "nextPhraseID":"gorwath_letter_52"
             }
         ],
+        
         "rewards":[
+            {
+                "rewardType":"questProgress",
+                "rewardID":"postman",
+                "value":10
+            },
             {
                 "rewardType":"questProgress",
                 "rewardID":"postman",


### PR DESCRIPTION
Same issue as the [url=https://andorstrail.com/viewtopic.php?t=7255] Warning General Ortholion's Henchmen Bug [/url]. Once you have a long talk to Gorwath and tap "leave" instead of choose between either "Yeah sure, why not?" or "No I'm busy. Good bye." 
You will not receive the quest item namely Gorwath's letter but you still receive the quest with only one dialogue "Gorwath would like me to give me a letter to Arensia, in Fallhaven." In other words, you cannot complete the quest because you don't have the required quest item to deliver it to the another NPC namely Arensia.