### PR TITLE
Let Signs & Key fields not show an empty dialog if they have no message text

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
@@ -66,14 +66,6 @@ public final class Dialogs {
 		CustomDialogFactory.show(d);
 	}
 
-	public static void showKeyArea(final MainActivity currentActivity, final ControllerContext context, String phraseID) {
-		showConversation(currentActivity, context, phraseID, null);
-	}
-
-	public static void showMapSign(final MainActivity currentActivity, final ControllerContext context, String phraseID) {
-		showConversation(currentActivity, context, phraseID, null);
-	}
-
 	public static void showMapScriptMessage(final MainActivity currentActivity, final ControllerContext context, String phraseID) {
 		showConversation(currentActivity, context, phraseID, null, false);
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
@@ -397,12 +397,10 @@ public final class MainActivity
 
 	@Override
 	public void onPlayerSteppedOnMapSignArea(MapObject area) {
-		Dialogs.showMapSign(this, controllers, area.id);
 	}
 
 	@Override
 	public void onPlayerSteppedOnKeyArea(MapObject area) {
-		Dialogs.showKeyArea(this, controllers, area.id);
 	}
 
 	@Override

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
@@ -68,6 +68,7 @@ public final class MapController {
 		case sign:
 			if (o.id == null || o.id.length() <= 0) return;
 			worldEventListeners.onPlayerSteppedOnMapSignArea(o);
+			runScriptInArea(o);
 			break;
 		case newmap:
 			if (o.map == null || o.place == null) return;
@@ -79,7 +80,7 @@ public final class MapController {
 			steppedOnRestArea(o);
 			break;
 		case script:
-			runScriptArea(o);
+			runScriptInArea(o);
 			break;
 		}
 	}
@@ -93,7 +94,7 @@ public final class MapController {
 		return true;
 	}
 
-	private void runScriptArea(MapObject o) {
+	private void runScriptInArea(MapObject o) {
 		Resources res = controllers.getResources();
 		mapScriptExecutor.proceedToPhrase(res, o.id, true, true);
 		controllers.mapController.applyCurrentMapReplacements(res, true);
@@ -164,6 +165,7 @@ public final class MapController {
 			return true;
 		}
 		worldEventListeners.onPlayerSteppedOnKeyArea(area);
+		runScriptInArea(area);
 		return false;
 	}
 


### PR DESCRIPTION
It makes them behave basically exactly like Scripts. They only show something when a Message has been provided.

---

#### Note:
Signs and Keys that have replies to choose without a message first might not be displayed (and executed after the reply) at all. This is already the case for Scripts and probably nothing that is being used, just something to be aware of.