### PR TITLE
Only add the loot once

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -250,7 +250,8 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		if (!loot.hasItemsOrGold()) {
 			world.model.currentMaps.map.removeGroundLoot(loot);
 		} else if (world.model.uiSelections.isInCombat) {
-			killedMonsterBags.add(loot);
+			if(!killedMonsterBags.contains(loot))
+				killedMonsterBags.add(loot);
 		}
 
 		combatActionListeners.onPlayerKilledMonster(killedMonster);


### PR DESCRIPTION
Without this, the loot might be added multiple times to the UI when showing what has been dropped, allowing the player to get more items than they should be allowed to