### PR TITLE
Implement basic auto attack

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/AndorsTrailPreferences.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/AndorsTrailPreferences.java
@@ -47,6 +47,7 @@ public final class AndorsTrailPreferences {
 	public int displayLoot = DISPLAYLOOT_DIALOG_ALWAYS;
 	public boolean fullscreen = true;
 	public int attackspeed_milliseconds = 1000;
+    public int autoAttackThreshold = -1;
 	public int movementMethod = MOVEMENTMETHOD_STRAIGHT;
 	public int movementAggressiveness = MOVEMENTAGGRESSIVENESS_NORMAL;
 	public float scalingFactor = 1.0f;
@@ -72,6 +73,7 @@ public final class AndorsTrailPreferences {
 			dest.displayLoot = Integer.parseInt(prefs.getString("display_lootdialog", Integer.toString(DISPLAYLOOT_DIALOG_ALWAYS)));
 			dest.fullscreen = prefs.getBoolean("fullscreen", true);
 			dest.attackspeed_milliseconds = Integer.parseInt(prefs.getString("attackspeed", "1000"));
+            dest.autoAttackThreshold = Integer.parseInt(prefs.getString("autoattackthreshold", "-1"));
 			dest.movementMethod = Integer.parseInt(prefs.getString("movementmethod", Integer.toString(MOVEMENTMETHOD_STRAIGHT)));
 			dest.scalingFactor = Float.parseFloat(prefs.getString("scaling_factor", "1.0f"));
 			dest.dpadPosition = Integer.parseInt(prefs.getString("dpadposition", Integer.toString(DPAD_POSITION_DISABLED)));
@@ -93,6 +95,7 @@ public final class AndorsTrailPreferences {
 			dest.displayLoot = DISPLAYLOOT_DIALOG_ALWAYS;
 			dest.fullscreen = true;
 			dest.attackspeed_milliseconds = 1000;
+            dest.autoAttackThreshold = -1;
 			dest.movementMethod = MOVEMENTMETHOD_STRAIGHT;
 			dest.movementAggressiveness = MOVEMENTAGGRESSIVENESS_NORMAL;
 			dest.scalingFactor = 1.0f;

--- a/AndorsTrail/res/values/arrays.xml
+++ b/AndorsTrail/res/values/arrays.xml
@@ -88,13 +88,15 @@
 	</string-array>
 
 	<string-array name="preferences_attackspeed">
-		<item>@string/preferences_attackspeed_instant</item>
+        <item>@string/preferences_attackspeed_instant_auto_attack</item>
+        <item>@string/preferences_attackspeed_instant</item>
 		<item>@string/preferences_attackspeed_fast</item>
 		<item>@string/preferences_attackspeed_normal</item>
 		<item>@string/preferences_attackspeed_slow</item>
 	</string-array>
 	<string-array name="preferences_attackspeed_values">
-		<item>0</item>
+        <item>-1</item>
+        <item>0</item>
 		<item>400</item>
 		<item>1000</item>
 		<item>1500</item>

--- a/AndorsTrail/res/values/arrays.xml
+++ b/AndorsTrail/res/values/arrays.xml
@@ -88,19 +88,36 @@
 	</string-array>
 
 	<string-array name="preferences_attackspeed">
-        <item>@string/preferences_attackspeed_instant_auto_attack</item>
         <item>@string/preferences_attackspeed_instant</item>
 		<item>@string/preferences_attackspeed_fast</item>
 		<item>@string/preferences_attackspeed_normal</item>
 		<item>@string/preferences_attackspeed_slow</item>
 	</string-array>
 	<string-array name="preferences_attackspeed_values">
-        <item>-1</item>
         <item>0</item>
 		<item>400</item>
 		<item>1000</item>
 		<item>1500</item>
 	</string-array>
+
+    <string-array name="preferences_auto_attack_threshold">
+        <item>@string/preferences_auto_attack_threshold_safe</item>
+        <item>@string/preferences_auto_attack_threshold_none</item>
+        <item>@string/preferences_auto_attack_threshold_90_percent_health_left</item>
+        <item>@string/preferences_auto_attack_threshold_80_percent_health_left</item>
+        <item>@string/preferences_auto_attack_threshold_70_percent_health_left</item>
+        <item>@string/preferences_auto_attack_threshold_60_percent_health_left</item>
+        <item>@string/preferences_auto_attack_threshold_50_percent_health_left</item>
+    </string-array>
+    <string-array name="preferences_auto_attack_threshold_values">
+        <item>-2</item>
+        <item>-1</item>
+        <item>90</item>
+        <item>80</item>
+        <item>70</item>
+        <item>60</item>
+        <item>50</item>
+    </string-array>
 
 	<string-array name="preferences_movementmethods">
 		<item>@string/preferences_movementmethods_straight</item>

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -315,6 +315,8 @@
 	<string name="preferences_combat_category">Combat</string>
 	<string name="preferences_combat_speed_title">Combat speed</string>
 	<string name="preferences_combat_speed">Determines how fast monsters attack.</string>
+    <string name="preferences_combat_auto_attack_threshold_title">Auto Attack Threshold</string>
+    <string name="preferences_combat_auto_attack_threshold">For each attack round, when should all the round\'s AP\'s be automatically used for attacking. **Combat Speed must be set to \'Instant\'**</string>
 
 	<string name="preferences_display_loot_dialog">Always show loot dialog box</string>
 	<string name="preferences_display_loot_dialog_on_items">Show loot dialog box when finding items</string>
@@ -323,11 +325,18 @@
 	<string name="preferences_display_loot_toast_on_items">Show notification only when finding items</string>
 	<string name="preferences_display_loot_never">Do not display</string>
 
-    <string name="preferences_attackspeed_instant_auto_attack">Instant Auto Attack (no animations, auto attack when cant be killed this round)</string>
     <string name="preferences_attackspeed_instant">Instant (no animations)</string>
 	<string name="preferences_attackspeed_fast">Fast</string>
 	<string name="preferences_attackspeed_normal">Normal</string>
 	<string name="preferences_attackspeed_slow">Slow</string>
+
+    <string name="preferences_auto_attack_threshold_safe">If can\'t be killed during monster\'s turn</string>
+    <string name="preferences_auto_attack_threshold_none">Do not Auto Attack</string>
+    <string name="preferences_auto_attack_threshold_90_percent_health_left">If health is greater than 90 percent</string>
+    <string name="preferences_auto_attack_threshold_80_percent_health_left">If health is greater than 80 percent</string>
+    <string name="preferences_auto_attack_threshold_70_percent_health_left">If health is greater than 70 percent</string>
+    <string name="preferences_auto_attack_threshold_60_percent_health_left">If health is greater than 60 percent</string>
+    <string name="preferences_auto_attack_threshold_50_percent_health_left">If health is greater than 50 percent</string>
 
 	<string name="preferences_movement_category">Movement</string>
 	<string name="preferences_movementmethod_title">Movement method</string>

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -323,7 +323,8 @@
 	<string name="preferences_display_loot_toast_on_items">Show notification only when finding items</string>
 	<string name="preferences_display_loot_never">Do not display</string>
 
-	<string name="preferences_attackspeed_instant">Instant (no animations)</string>
+    <string name="preferences_attackspeed_instant_auto_attack">Instant Auto Attack (no animations, auto attack when cant be killed this round)</string>
+    <string name="preferences_attackspeed_instant">Instant (no animations)</string>
 	<string name="preferences_attackspeed_fast">Fast</string>
 	<string name="preferences_attackspeed_normal">Normal</string>
 	<string name="preferences_attackspeed_slow">Slow</string>

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -323,7 +323,7 @@
 	<string name="preferences_display_loot_toast_on_items">Show notification only when finding items</string>
 	<string name="preferences_display_loot_never">Do not display</string>
 
-    <string name="preferences_attackspeed_instant_auto_attack">Instant Auto Attack (no animations, auto attack when cant be killed this round)</string>
+    <string name="preferences_attackspeed_instant_auto_attack">Instant Auto Attack (no animations, auto attack when max raw damage of monster(s) is less than player health - doesnt account for actor conditions)</string>
     <string name="preferences_attackspeed_instant">Instant (no animations)</string>
 	<string name="preferences_attackspeed_fast">Fast</string>
 	<string name="preferences_attackspeed_normal">Normal</string>

--- a/AndorsTrail/res/xml/preferences.xml
+++ b/AndorsTrail/res/xml/preferences.xml
@@ -68,6 +68,13 @@
 			android:defaultValue="1000"
 			android:entries="@array/preferences_attackspeed"
 			android:entryValues="@array/preferences_attackspeed_values" />
+        <com.gpl.rpg.AndorsTrail.view.CustomListPreference
+            android:title="@string/preferences_combat_auto_attack_threshold_title"
+            android:summary="@string/preferences_combat_auto_attack_threshold"
+            android:key="autoattackthreshold"
+            android:defaultValue="-1"
+            android:entries="@array/preferences_auto_attack_threshold"
+            android:entryValues="@array/preferences_auto_attack_threshold_values" />
 	</PreferenceCategory>
 	<PreferenceCategory
 		android:title="@string/preferences_movement_category">


### PR DESCRIPTION
Add preference/setting and logic for basic auto attack. If its the players turn, they have enough AP for an attack, and they cant be killed during the next monster's turn, then automatically execute the players attack. 

### Copilot Summary
This pull request introduces an auto-attack threshold feature to the combat system, allowing players to configure when all available action points (APs) are automatically used for attacking during their turn. The feature is configurable via the preferences UI, with several threshold options based on player health or a "safe" mode. The implementation includes both backend logic and UI updates.

**Combat System Enhancements:**
* Added an auto-attack threshold mechanic in `CombatController`, including logic to determine when the player should auto-attack based on the selected threshold (e.g., "safe" mode, health percentage), and integrated this into the player turn flow.
* Implemented helper methods `getMaxDamagePerHit` and `getMaxDamagePerTurn` to support the "safe" auto-attack threshold logic, ensuring the player will not be auto-attacked if they could be killed during the monsters' turn.

**Preferences and Settings:**
* Added the `autoAttackThreshold` field to `AndorsTrailPreferences`, including logic to read/write this value from preferences and set its default. [[1]](diffhunk://#diff-3da8e554f0dde596d692c9fadfc0b39fff4452b789d9d9ffab0284f85fa86998R50) [[2]](diffhunk://#diff-3da8e554f0dde596d692c9fadfc0b39fff4452b789d9d9ffab0284f85fa86998R76) [[3]](diffhunk://#diff-3da8e554f0dde596d692c9fadfc0b39fff4452b789d9d9ffab0284f85fa86998R98)
* Updated the preferences UI (`preferences.xml`) to include a new setting for auto-attack threshold, with corresponding entries and values in `arrays.xml` and descriptive strings in `strings.xml`. [[1]](diffhunk://#diff-f061524bdd9b94a0aa78d25ef2c8e489cfefbbf2edfd0336f8f1a3a33d9719d5R71-R77) [[2]](diffhunk://#diff-2d467792e2cf277c6b34a223d883e2927229fd04951e98a38dab39f6c8208ab0R103-R121) [[3]](diffhunk://#diff-9a3db8d66ef0cb958ffc28e594aaf1609187fddf6bb9f713af38b1f57c309677R318-R319) [[4]](diffhunk://#diff-9a3db8d66ef0cb958ffc28e594aaf1609187fddf6bb9f713af38b1f57c309677R333-R340)