### PR TITLE
try to fix an exploit to speed up rounds

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
@@ -139,7 +139,7 @@ public final class MainActivity
 			if (resultCode == Activity.RESULT_OK) {
 				controllers.combatController.enterCombat(CombatController.BeginTurnAs.player);
 			} else {
-				controllers.combatController.exitCombat(false);
+				controllers.combatController.exitCombat(false, true);
 			}
 			break;
 		case INTENTREQUEST_CONVERSATION:

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -57,6 +57,9 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		else continueTurn();
 	}
 	public void exitCombat(boolean pickupLootBags) {
+		exitCombat(pickupLootBags, false);
+	}
+	public void exitCombat(boolean pickupLootBags, boolean canceledCombat) {
 		setCombatSelection(null, null);
 		world.model.uiSelections.isInCombat = false;
 		if (pickupLootBags) {
@@ -66,7 +69,7 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		controllers.actorStatsController.setActorMaxAP(world.model.player);
 		world.model.uiSelections.selectedPosition = null;
 		world.model.uiSelections.selectedMonster = null;
-		if (world.model.player.isDead()) {
+		if (world.model.player.isDead() || canceledCombat) {
 			controllers.gameRoundController.resetRoundTimers();
 		} else {
 			endOfCombatRound();


### PR DESCRIPTION
this can be triggered by
 - walking up to an enemy
 - get the popup to attack it
 - cancel it, which finishes the round
 - repeat

with this it is very easy to for example use a heal over time food in a very short time or getting rid of an unwanted actor condition

the fix tries to just not grant a finished round when closing the window asking if the player wants to start attacking