### PR TITLE
Item Filters

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/context/WorldContext.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/context/WorldContext.java
@@ -7,6 +7,7 @@ import com.gpl.rpg.AndorsTrail.model.ability.SkillCollection;
 import com.gpl.rpg.AndorsTrail.model.actor.MonsterTypeCollection;
 import com.gpl.rpg.AndorsTrail.model.item.DropListCollection;
 import com.gpl.rpg.AndorsTrail.model.item.ItemCategoryCollection;
+import com.gpl.rpg.AndorsTrail.model.item.ItemFilterCollection;
 import com.gpl.rpg.AndorsTrail.model.item.ItemTypeCollection;
 import com.gpl.rpg.AndorsTrail.model.map.MapCollection;
 import com.gpl.rpg.AndorsTrail.model.quest.QuestCollection;
@@ -20,6 +21,7 @@ public final class WorldContext {
 	//Objectcollections
 	public final ConversationLoader conversationLoader;
 	public final ItemTypeCollection itemTypes;
+	public final ItemFilterCollection itemFilters;
 	public final ItemCategoryCollection itemCategories;
 	public final MonsterTypeCollection monsterTypes;
 	public final VisualEffectCollection visualEffectTypes;
@@ -38,6 +40,7 @@ public final class WorldContext {
 	public WorldContext() {
 		this.conversationLoader = new ConversationLoader();
 		this.itemTypes = new ItemTypeCollection();
+		this.itemFilters = new ItemFilterCollection();
 		this.itemCategories = new ItemCategoryCollection();
 		this.monsterTypes = new MonsterTypeCollection();
 		this.visualEffectTypes = new VisualEffectCollection();
@@ -51,6 +54,7 @@ public final class WorldContext {
 	public WorldContext(WorldContext copy) {
 		this.conversationLoader = copy.conversationLoader;
 		this.itemTypes = copy.itemTypes;
+		this.itemFilters = copy.itemFilters;
 		this.itemCategories = copy.itemCategories;
 		this.monsterTypes = copy.monsterTypes;
 		this.visualEffectTypes = copy.visualEffectTypes;

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/Constants.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/Constants.java
@@ -49,6 +49,7 @@ public final class Constants {
 	public static final String FILENAME_SAVEGAME_FILENAME_PREFIX = "savegame";
 	public static final String PLACEHOLDER_PLAYERNAME = "$playername";
 	public static final String PLACEHOLDER_REQUIRE_ITEM_ID = "$requireitem";
+	public static final String ITEMFILTER_ID_PREFIX = "#";
 	public static final String CHEAT_DETECTION_FOLDER = "dEAGyGE3YojqXjI3x4x7";
 	public static final String PASSIVE_ACHIEVEMENT_CHECK_PHRASE = "passive_achievement_check";
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/Constants.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/Constants.java
@@ -48,7 +48,6 @@ public final class Constants {
 	public static final String FILENAME_WORLDMAP_HTMLFILE_SUFFIX = ".html";
 	public static final String FILENAME_SAVEGAME_FILENAME_PREFIX = "savegame";
 	public static final String PLACEHOLDER_PLAYERNAME = "$playername";
-	public static final String PLACEHOLDER_REQUIRE_ITEM_ID = "$requireitem";
 	public static final String ITEMFILTER_ID_PREFIX = "#";
 	public static final String CHEAT_DETECTION_FOLDER = "dEAGyGE3YojqXjI3x4x7";
 	public static final String PASSIVE_ACHIEVEMENT_CHECK_PHRASE = "passive_achievement_check";

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/Constants.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/Constants.java
@@ -48,6 +48,7 @@ public final class Constants {
 	public static final String FILENAME_WORLDMAP_HTMLFILE_SUFFIX = ".html";
 	public static final String FILENAME_SAVEGAME_FILENAME_PREFIX = "savegame";
 	public static final String PLACEHOLDER_PLAYERNAME = "$playername";
+	public static final String PLACEHOLDER_REQUIRE_ITEM_ID = "$requireitem";
 	public static final String CHEAT_DETECTION_FOLDER = "dEAGyGE3YojqXjI3x4x7";
 	public static final String PASSIVE_ACHIEVEMENT_CHECK_PHRASE = "passive_achievement_check";
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
@@ -543,39 +543,9 @@ public final class ConversationController {
 				if (!canSelectReply(world, r)) {
 					continue;
 				}
-				if (r.text.toLowerCase().contains(Constants.PLACEHOLDER_REQUIRE_ITEM_ID) && r.hasRequirements()) {
-					for (Requirement requirement : r.requires) {
-						switch (requirement.requireType) {
-							case inventoryKeep:
-							case inventoryRemove:
-							case wear:
-							case wearRemove:
-							case usedItem:
-								proceedToPhraseWithItem(r, requirement);
-								break;
-						}
-					}
-				} else {
-					listener.onConversationHasReply(r, getDisplayMessage(r, player));
-				}
+				listener.onConversationHasReply(r, getDisplayMessage(r, player));
 			}
 			return null;
-		}
-
-		private void proceedToPhraseWithItem(Reply r, Requirement requirement) {
-			List<ItemType> validItems = new ArrayList<>();
-			if (ItemTypeCollection.isItemFilter(requirement.requireID)) {
-				validItems = world.itemFilters.getItemFilter(requirement.requireID).getItemTypes();
-			} else {
-				validItems.add(world.itemTypes.getItemType(requirement.requireID));
-			}
-			for (ItemType item : validItems) {
-				// This generates a reply for every matching item, if the player happens to have it in their inventory TODO: When no placeholder is present, only give one reply option
-				if (player.inventory.getItemQuantity(item.id) >= requirement.value) {
-					Reply itemReply = new Reply(r.text.replace(Constants.PLACEHOLDER_REQUIRE_ITEM_ID, item.getName(player)), r.nextPhrase, r.requires);
-					listener.onConversationHasReply(itemReply, getDisplayMessage(itemReply, player));
-				}
-			}
 		}
 
 		private void endConversationWithRemovingNPC() {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
@@ -222,7 +222,12 @@ public final class ConversationController {
 	}
 
 	private void addItemReward(String itemTypeID, int quantity, ScriptEffectResult result) {
-		result.loot.add(world.itemTypes.getItemType(itemTypeID), quantity);
+		if (ItemTypeCollection.isItemFilter(itemTypeID)) {
+			ItemFilter filter = world.itemFilters.getItemFilter(itemTypeID);
+			result.loot.add(filter.getRandomItem(), quantity);
+		} else {
+			result.loot.add(world.itemTypes.getItemType(itemTypeID), quantity);
+		}
 	}
 
 	private void addSkillReward(Player player, SkillCollection.SkillID skillID, ScriptEffectResult result) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/SkillController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/SkillController.java
@@ -58,15 +58,15 @@ public final class SkillController {
 		}*/
 	}
 
-	public static int getDropChanceRollBias(DropItem item, Player player) {
+	public static int getDropChanceRollBias(DropItem item, ItemType itemType, Player player) {
 		if (player == null) return 0;
-		if(item.itemType == null && AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES){
+		if(item.itemTypeID == null && AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES){
 			L.log("Item type missing: " + item + " " + player.id);
 		}
 
-		if (ItemTypeCollection.isGoldItemType(item.itemType.id)) {
+		if (ItemTypeCollection.isGoldItemType(item.itemTypeID)) {
 			return getRollBias(item, player, SkillID.coinfinder, SkillCollection.PER_SKILLPOINT_INCREASE_COINFINDER_CHANCE_PERCENT);
-		} else if (!item.itemType.isOrdinaryItem()) {
+		} else if (!itemType.isOrdinaryItem()) {
 			return getRollBias(item, player, SkillID.magicfinder, SkillCollection.PER_SKILLPOINT_INCREASE_MAGICFINDER_CHANCE_PERCENT);
 		} else {
 			return 0;
@@ -75,7 +75,7 @@ public final class SkillController {
 
 	public static int getDropQuantityRollBias(DropItem item, Player player) {
 		if (player == null) return 0;
-		if (!ItemTypeCollection.isGoldItemType(item.itemType.id)) return 0;
+		if (!ItemTypeCollection.isGoldItemType(item.itemTypeID)) return 0;
 
 		return getRollBias(item.quantity, player, SkillID.coinfinder, SkillCollection.PER_SKILLPOINT_INCREASE_COINFINDER_QUANTITY_PERCENT);
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/DropList.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/DropList.java
@@ -25,7 +25,7 @@ public final class DropList {
 		for (DropItem item : items) {
 
 			if (ItemTypeCollection.isItemFilter(item.itemTypeID)) {
-				ItemFilter itemFilter = itemFilterCollection.getItemFilter(ItemTypeCollection.getItemFilterID(item.itemTypeID));
+				ItemFilter itemFilter = itemFilterCollection.getItemFilter(item.itemTypeID);
 				item = new DropItem(
 						itemFilter.getRandomItem().id
 						, item.chance

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemFilter.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemFilter.java
@@ -1,0 +1,34 @@
+package com.gpl.rpg.AndorsTrail.model.item;
+
+import com.gpl.rpg.AndorsTrail.controller.Constants;
+import com.gpl.rpg.AndorsTrail.util.Range;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class ItemFilter {
+
+    public final String id;
+    private final List<ItemType> include;
+
+
+    public ItemFilter(
+            String id
+            , List<ItemType> include
+    ) {
+        this.id = id;
+        this.include = include;
+    }
+
+    public List<ItemType> getItemTypes() {
+        if (include == null || include.isEmpty())
+            return Collections.emptyList();
+        return include;
+    }
+
+    public ItemType getRandomItem() {
+        List<ItemType> allItemsInFilter = getItemTypes();
+        int ran = Constants.rollValue(new Range(allItemsInFilter.size()-1, 0));
+        return allItemsInFilter.get(ran);
+    }
+}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemFilterCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemFilterCollection.java
@@ -1,0 +1,28 @@
+package com.gpl.rpg.AndorsTrail.model.item;
+
+import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
+import com.gpl.rpg.AndorsTrail.resource.parsers.ItemFilterParser;
+import com.gpl.rpg.AndorsTrail.util.L;
+
+import java.util.HashMap;
+
+public class ItemFilterCollection {
+    private final HashMap<String, ItemFilter> itemFilters = new HashMap<String, ItemFilter>();
+
+
+    public ItemFilter getItemFilter(String id) {
+        id = ItemTypeCollection.getItemFilterID(id);
+
+        if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
+            if (!itemFilters.containsKey(id)) {
+                L.log("WARNING: Cannot find ItemFilter for id \"" + id + "\".");
+                return null;
+            }
+        }
+        return itemFilters.get(id);
+    }
+
+    public void initialize(final ItemFilterParser parser, String input) {
+        parser.parseRows(input, itemFilters);
+    }
+}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemTypeCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemTypeCollection.java
@@ -3,6 +3,7 @@ package com.gpl.rpg.AndorsTrail.model.item;
 import java.util.HashMap;
 
 import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
+import com.gpl.rpg.AndorsTrail.controller.Constants;
 import com.gpl.rpg.AndorsTrail.resource.parsers.ItemTypeParser;
 import com.gpl.rpg.AndorsTrail.util.L;
 
@@ -28,11 +29,11 @@ public final class ItemTypeCollection {
 
 	public static boolean isItemFilter(String itemTypeID) {
 		if (itemTypeID == null) return false;
-		return itemTypeID.toLowerCase().startsWith("filter:");
+		return itemTypeID.toLowerCase().startsWith(Constants.ITEMFILTER_ID_PREFIX);
 	}
 	public static String getItemFilterID(String itemTypeID) {
 		if (isItemFilter(itemTypeID))
-			return itemTypeID.substring(7);
+			return itemTypeID.substring(Constants.ITEMFILTER_ID_PREFIX.length());
 		else return itemTypeID;
 	}
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemTypeCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/item/ItemTypeCollection.java
@@ -26,6 +26,16 @@ public final class ItemTypeCollection {
 		return itemTypeID.equals(ITEMTYPE_GOLD);
 	}
 
+	public static boolean isItemFilter(String itemTypeID) {
+		if (itemTypeID == null) return false;
+		return itemTypeID.toLowerCase().startsWith("filter:");
+	}
+	public static String getItemFilterID(String itemTypeID) {
+		if (isItemFilter(itemTypeID))
+			return itemTypeID.substring(7);
+		else return itemTypeID;
+	}
+
 	public void initialize(final ItemTypeParser parser, String input) {
 		parser.parseRows(input, itemTypes);
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/ResourceLoader.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/ResourceLoader.java
@@ -18,6 +18,7 @@ import com.gpl.rpg.AndorsTrail.resource.parsers.ActorConditionsTypeParser;
 import com.gpl.rpg.AndorsTrail.resource.parsers.ConversationListParser;
 import com.gpl.rpg.AndorsTrail.resource.parsers.DropListParser;
 import com.gpl.rpg.AndorsTrail.resource.parsers.ItemCategoryParser;
+import com.gpl.rpg.AndorsTrail.resource.parsers.ItemFilterParser;
 import com.gpl.rpg.AndorsTrail.resource.parsers.ItemTypeParser;
 import com.gpl.rpg.AndorsTrail.resource.parsers.MonsterTypeParser;
 import com.gpl.rpg.AndorsTrail.resource.parsers.QuestParser;
@@ -30,6 +31,7 @@ public final class ResourceLoader {
 	private static final int itemCategoriesResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_itemcategories_debug : R.array.loadresource_itemcategories;
 	private static final int actorConditionsResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_actorconditions_debug : R.array.loadresource_actorconditions;
 	private static final int itemsResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_items_debug : R.array.loadresource_items;
+	private static final int itemFiltersResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_itemfilters_debug : R.array.loadresource_itemfilters;
 	private static final int droplistsResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_droplists_debug : R.array.loadresource_droplists;
 	private static final int questsResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_quests_debug : R.array.loadresource_quests;
 	private static final int conversationsListsResourceId = AndorsTrailApplication.DEVELOPMENT_DEBUGRESOURCES ? R.array.loadresource_conversationlists_debug : R.array.loadresource_conversationlists;
@@ -143,10 +145,20 @@ public final class ResourceLoader {
 		itemsToLoad.recycle();
 		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) timingCheckpoint("ItemTypeParser");
 
+		// ========================================================================
+		// Load item filters
+		final ItemFilterParser itemFilterParser = new ItemFilterParser(world.itemTypes);
+		final TypedArray itemFiltersToLoad = r.obtainTypedArray(itemFiltersResourceId);
+		for (int i = 0; i < itemFiltersToLoad.length(); ++i) {
+			String s = readStringFromRaw(r, itemFiltersToLoad, i);
+			world.itemFilters.initialize(itemFilterParser, s);
+		}
+		itemFiltersToLoad.recycle();
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) timingCheckpoint("ItemFilterParser");
 
 		// ========================================================================
 		// Load droplists
-		final DropListParser dropListParser = new DropListParser(world.itemTypes);
+		final DropListParser dropListParser = new DropListParser(world.itemTypes, world.itemFilters);
 		final TypedArray droplistsToLoad = r.obtainTypedArray(droplistsResourceId);
 		for (int i = 0; i < droplistsToLoad.length(); ++i) {
 			world.dropLists.initialize(dropListParser, readStringFromRaw(r, droplistsToLoad, i));

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/parsers/DropListParser.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/parsers/DropListParser.java
@@ -6,6 +6,7 @@ import org.json.JSONObject;
 import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
 import com.gpl.rpg.AndorsTrail.model.item.DropList;
 import com.gpl.rpg.AndorsTrail.model.item.DropList.DropItem;
+import com.gpl.rpg.AndorsTrail.model.item.ItemFilterCollection;
 import com.gpl.rpg.AndorsTrail.model.item.ItemTypeCollection;
 import com.gpl.rpg.AndorsTrail.resource.parsers.json.JsonArrayParserFor;
 import com.gpl.rpg.AndorsTrail.resource.parsers.json.JsonCollectionParserFor;
@@ -16,13 +17,17 @@ import android.util.Pair;
 public final class DropListParser extends JsonCollectionParserFor<DropList> {
 
 	private final JsonArrayParserFor<DropItem> dropItemParser;
+	private final ItemTypeCollection itemTypeCollection;
+	private final ItemFilterCollection itemFilterCollection;
 
-	public DropListParser(final ItemTypeCollection itemTypes) {
+	public DropListParser(final ItemTypeCollection itemTypeCollection, final ItemFilterCollection itemFilterCollection) {
+		this.itemTypeCollection = itemTypeCollection;
+		this.itemFilterCollection = itemFilterCollection;
 		this.dropItemParser = new JsonArrayParserFor<DropItem>(DropItem.class) {
 			@Override
 			protected DropItem parseObject(JSONObject o) throws JSONException {
 				return new DropItem(
-						itemTypes.getItemType(o.getString(JsonFieldNames.DropItem.itemID))
+						o.getString(JsonFieldNames.DropItem.itemID)
 						,ResourceParserUtils.parseChance(o.getString(JsonFieldNames.DropItem.chance))
 						,ResourceParserUtils.parseQuantity(o.getJSONObject(JsonFieldNames.DropItem.quantity))
 				);
@@ -41,12 +46,16 @@ public final class DropListParser extends JsonCollectionParserFor<DropList> {
 			}
 			for (int i = 0; i < items.length; i++) {
 				DropItem item = items[i];
-				if (item.itemType == null) {
+				if (item.itemTypeID == null) {
 					L.log("Item at index " + i + " in droplist " + droplistID + " was null");
 				}
 			}
 		}
 
-		return new Pair<String, DropList>(droplistID, new DropList(items));
+		return new Pair<>(droplistID, new DropList(
+                items
+                , itemTypeCollection
+                , itemFilterCollection
+        ));
 	}
 }

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/parsers/ItemFilterParser.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/parsers/ItemFilterParser.java
@@ -1,0 +1,45 @@
+package com.gpl.rpg.AndorsTrail.resource.parsers;
+
+import android.util.Pair;
+
+import com.gpl.rpg.AndorsTrail.model.item.ItemFilter;
+import com.gpl.rpg.AndorsTrail.model.item.ItemType;
+import com.gpl.rpg.AndorsTrail.model.item.ItemTypeCollection;
+import com.gpl.rpg.AndorsTrail.resource.parsers.json.JsonCollectionParserFor;
+import com.gpl.rpg.AndorsTrail.resource.parsers.json.JsonFieldNames;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ItemFilterParser extends JsonCollectionParserFor<ItemFilter> {
+
+    private final ItemTypeCollection itemTypeCollection;
+
+    public ItemFilterParser(final ItemTypeCollection itemTypeCollection) {
+        this.itemTypeCollection = itemTypeCollection;
+    }
+
+    @Override
+    public Pair<String, ItemFilter> parseObject(JSONObject o) throws JSONException {
+        final String id = o.getString(JsonFieldNames.ItemFilter.itemFilterID);
+        final JSONArray includeJson = o.optJSONArray(JsonFieldNames.ItemFilter.include);
+
+        List<ItemType> include = new ArrayList<>();
+
+        if (includeJson != null) {
+            for (int i = 0; i < includeJson.length(); i++) {
+                include.add(itemTypeCollection.getItemType(includeJson.getString(i)));
+            }
+        }
+
+        final ItemFilter itemFilter = new ItemFilter(
+                id
+                , include
+        );
+        return new Pair<>(id, itemFilter);
+    }
+}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/parsers/json/JsonFieldNames.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/resource/parsers/json/JsonFieldNames.java
@@ -174,5 +174,8 @@ public final class JsonFieldNames {
 		public static final String missReceivedEffect = "missReceivedEffect";
 	}
 
-
+	public static final class ItemFilter {
+		public static final String itemFilterID = "id";
+		public static final String include = "include";
+	}
 }

--- a/AndorsTrail/res/raw/itemfilters.json
+++ b/AndorsTrail/res/raw/itemfilters.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "gael_meat",
+    "include": [
+      "meat",
+      "meat2"
+    ]
+  }
+]

--- a/AndorsTrail/res/raw/itemfilters_debug.json
+++ b/AndorsTrail/res/raw/itemfilters_debug.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "debug_any",
+    "includeTags": [
+      "animal_part"
+    ]
+  },
+  {
+    "id": "debug_all",
+    "includeTags": [
+      "animal_part",
+      "poisonous"
+    ]
+  },
+  {
+    "id": "debug_exact",
+    "includeTags": [
+      "animal_part"
+    ]
+  }
+]

--- a/AndorsTrail/res/values/loadresources.xml
+++ b/AndorsTrail/res/values/loadresources.xml
@@ -129,7 +129,11 @@
         <!--Added by ATCS v0.6.21 for project mt_galmore2-->
         <item>@raw/itemlist_mt_galmore2</item>
     </array>
-        
+
+    <array name="loadresource_itemfilters">
+        <item>@raw/itemfilters</item>
+    </array>
+
     <array name="loadresource_droplists">
         <item>@raw/droplists_crossglen</item>
         <item>@raw/droplists_crossglen_outside</item>

--- a/AndorsTrail/res/values/loadresources_debug.xml
+++ b/AndorsTrail/res/values/loadresources_debug.xml
@@ -15,6 +15,10 @@
 		<item>@raw/itemlist_debug</item>
 	</array>
 
+	<array name="loadresource_itemfilters_debug">
+		<item>@raw/itemfilters_debug</item>
+	</array>
+
 	<array name="loadresource_droplists_debug">
 		<item>@raw/droplists_debug</item>
 	</array>


### PR DESCRIPTION
ItemFilters are a simple list of ItemTypes. They can be used in the following places where ItemIDs are required:
- Dialog Requirements: inventoryKeep, inventoryRemove, wear, wearRemove, usedItem
- Dialog Rewards: giveItem
- Droplists (for drops or shops)
To call an ItemFilter instead of an ItemType, put a "#" in front of the ID (in the respective json file, prefix can be changed in Constants)

So far, when an ItemFilter is used for inventoryRemove or wearRemove, an item is selected by first search result. In droplists and giveItem, a random item from the filter is selected.

I plan on adding a feature to let the player select which item he wants to have removed, but this requires me to add a "ConversationContext" to pass on the selection down to the next NPC message.