### PR TITLE
Ability to concatenate dialogs

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ConversationController.java
@@ -555,13 +555,21 @@ public final class ConversationController {
 				}
 			}
 
-			if (currentPhrase.message == null) {
-				for (Reply r : currentPhrase.replies) {
-					if (!canSelectReply(world, r)) continue;
+			for (Reply r : currentPhrase.replies) {
+				if (!canSelectReply(world, r)) continue;
+				if (currentPhrase.message == null) {
 					applyReplyEffect(world, r, controllers);
 					return r.nextPhrase;
 				}
-			} else if (displayPhraseMessage) {
+				if (r.text.equals(ConversationCollection.REPLY_CONCAT)) {
+					Phrase phrase = conversationCollection.getPhrase(r.nextPhrase);
+					if (phrase != null) phrase.message = currentPhrase.message + "\n" + phrase.message;
+					applyReplyEffect(world, r, controllers);
+					return r.nextPhrase;
+				}
+			}
+
+			if (displayPhraseMessage) {
 				String message = getDisplayMessage(currentPhrase, player);
 				listener.onTextPhraseReached(message, npc, phraseID);
 			}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/conversation/ConversationCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/conversation/ConversationCollection.java
@@ -13,6 +13,7 @@ public final class ConversationCollection {
 	public static final String PHRASE_ATTACK = "F";
 	public static final String PHRASE_REMOVE = "R";
 	public static final String REPLY_NEXT = "N";
+	public static final String REPLY_CONCAT = "C";
 
 	private final HashMap<String, Phrase> phrases = new HashMap<String, Phrase>();
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/conversation/Phrase.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/conversation/Phrase.java
@@ -5,7 +5,7 @@ import com.gpl.rpg.AndorsTrail.model.script.ScriptEffect;
 public final class Phrase {
 	private static final Reply[] NO_REPLIES = new Reply[0];
 
-	public final String message;
+	public String message;
 	public final Reply[] replies;
 	public final ScriptEffect[] scriptEffects; // If this phrase is reached, all these effects will run
 	public final String switchToNPC;


### PR DESCRIPTION
A quick one here, it does what it should but please review if there are no side effects.

What I added:
You can now put "C" as a reply message similar to "N", but instead of having the user click on "Next" to display the upcoming message, it concatenates the dialog messages with a line break. Might be useful in some cases to create dynamic messages.

E.g.
```
    {
        "id": "test1",
        "message": "Hello",
        "replies": [
            {
                "text": "C",
                "nextPhraseID": "test2"
            }
        ]
    },
    {
        "id": "test2",
        "message": "World"
    }
```
result: 
```
NPC: Hello
World
```

What I am still unhappy about:
- In the ConversationController, we now iterate over every Reply twice, no matter if the message is null or not.
- In Phrase, I had to remove the finality of message in order to alter it.
- It always uses a line break as a concatenator, would be nice if you could choose from several strings.

If anyone can do this in a better way, feel free to edit.