### PR TITLE
fix whitespace and invalid characters in IDs.  

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/actor/Player.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/actor/Player.java
@@ -56,8 +56,9 @@ public final class Player extends Actor {
 	private final HashMap<String, Integer> alignments = new HashMap<String, Integer>();
 	public String id = UUID.randomUUID().toString();
 	public long savedVersion = 1; // the version get's increased for cheat detection everytime a player with limited saves is saved
-
-
+	// Fixup for a bad quest ID
+	private static final String LEGACY_MISC_NONDISPLAY_QUEST_ID = "misc_nondisplay ";
+	private static final String FIXED_MISC_NONDISPLAY_QUEST_ID = "misc_nondisplay";
 
 	// Unequipped stats
 	public static final class PlayerBaseTraits {
@@ -374,7 +375,10 @@ public final class Player extends Actor {
 			LinkedHashMap<String, LinkedHashSet<Integer> > questProgress = new LinkedHashMap<String, LinkedHashSet<Integer> >();
 			final int numQuests = src.readInt();
 			for(int i = 0; i < numQuests; ++i) {
-				final String questID = src.readUTF();
+				final String savedQuestID = src.readUTF();
+				final String questID = LEGACY_MISC_NONDISPLAY_QUEST_ID.equals(savedQuestID)
+						? FIXED_MISC_NONDISPLAY_QUEST_ID
+						: savedQuestID;
 				questProgress.put(questID, new LinkedHashSet<Integer>());
 				final int numProgress = src.readInt();
 
@@ -546,4 +550,3 @@ public final class Player extends Actor {
 		builder.add(savedVersion);
 	}
 }
-

--- a/AndorsTrail/res/raw/conversationlist_arulir_mountain.json
+++ b/AndorsTrail/res/raw/conversationlist_arulir_mountain.json
@@ -2137,7 +2137,7 @@
                 "requires":[
                     {
                         "requireType":"questProgress",
-                        "requireID":"misc_nondisplay ",
+                        "requireID":"misc_nondisplay",
                         "value":10,
                         "negate":true
                     }
@@ -2156,7 +2156,7 @@
             },
             {
                 "rewardType":"questProgress",
-                "rewardID":"misc_nondisplay ",
+                "rewardID":"misc_nondisplay",
                 "value":10
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_brightport.json
+++ b/AndorsTrail/res/raw/conversationlist_brightport.json
@@ -10776,7 +10776,7 @@
     {
         "id":"brightport_crate_success",
         "message":"After what seems like a minute the footsteps move away, you hear the guards discuss something then silence.",
-        "switchToNPC":"$playername",
+        "switchToNPC":"none",
         "replies":[
             {
                 "text":"Time to get out of this crate.",
@@ -12199,7 +12199,7 @@
         ]
     },
     {
-        "id":"brightport_nothing "
+        "id":"brightport_nothing"
     },
     {
         "id":"brightport_dominio",

--- a/AndorsTrail/res/raw/conversationlist_fallhaven_tavern.json
+++ b/AndorsTrail/res/raw/conversationlist_fallhaven_tavern.json
@@ -73,7 +73,7 @@
                 "requires":[
                     {
                         "requireType":"questProgress",
-                        "requireID":"misc_nondisplay ",
+                        "requireID":"misc_nondisplay",
                         "value":20
                     }
                 ]

--- a/AndorsTrail/res/raw/conversationlist_feygard_1.json
+++ b/AndorsTrail/res/raw/conversationlist_feygard_1.json
@@ -4873,7 +4873,7 @@
             },
             {
                 "text":"[Throw an Oegyth Crystal]",
-                "nextPhraseID":"wexlow_well_throw_oegyth _crystal",
+                "nextPhraseID":"wexlow_well_throw_oegyth_crystal",
                 "requires":[
                     {
                         "requireType":"inventoryRemove",
@@ -4928,7 +4928,7 @@
         ]
     },
     {
-        "id":"wexlow_well_throw_oegyth _crystal",
+        "id":"wexlow_well_throw_oegyth_crystal",
         "message":"Glowing thing... pretty, but useless! Gamjee no care for it!",
         "switchToNPC":"well_voice",
         "replies":[

--- a/AndorsTrail/res/raw/conversationlist_omi2.json
+++ b/AndorsTrail/res/raw/conversationlist_omi2.json
@@ -7507,7 +7507,7 @@
                     },
                     {
                         "requireType":"factionScore",
-                        "requireID":"elm2f:_crack",
+                        "requireID":"elm2f_crack",
                         "value":10,
                         "negate":true
                     }

--- a/AndorsTrail/res/raw/conversationlist_omicronrg9.json
+++ b/AndorsTrail/res/raw/conversationlist_omicronrg9.json
@@ -4905,7 +4905,7 @@
         "rewards":[
             {
                 "rewardType":"questProgress",
-                "rewardID":"misc_nondisplay ",
+                "rewardID":"misc_nondisplay",
                 "value":20
             }
         ]

--- a/AndorsTrail/res/raw/conversationlist_sullengard.json
+++ b/AndorsTrail/res/raw/conversationlist_sullengard.json
@@ -4779,12 +4779,12 @@
         "replies":[
             {
                 "text":"Oh, sorry, but this sounds exciting.",
-                "nextPhraseID":"ff_captain_beer_ 40"
+                "nextPhraseID":"ff_captain_beer_40"
             }
         ]
     },
     {
-        "id":"ff_captain_beer_ 40",
+        "id":"ff_captain_beer_40",
         "message":"Well, if you look around this tavern, both inside and outside, do you notice anything?",
         "replies":[
             {
@@ -4823,12 +4823,12 @@
         "replies":[
             {
                 "text":"Understood, but I am still not seeing how this means that a law has been broken.",
-                "nextPhraseID":" ff_captain_beer_80"
+                "nextPhraseID":"ff_captain_beer_80"
             }
         ]
     },
     {
-        "id":" ff_captain_beer_80",
+        "id":"ff_captain_beer_80",
         "message":"Well, you see kid, I used to work in the 'tax collection' division of the Feygard patrol and I don't ever remember seeing the kind of collected taxes that would reflect this kind of volume of beer.",
         "replies":[
             {
@@ -4865,7 +4865,7 @@
             },
             {
                 "text":"Sounds easy. I'll do it.",
-                "nextPhraseID":"ff_captain_beer_ 111"
+                "nextPhraseID":"ff_captain_beer_111"
             }
         ],
         "rewards":[
@@ -4881,8 +4881,8 @@
         "message":"Well, because I am a Feygard captain and as such, the tavern keep will never give me information."
     },
     {
-        "id":"ff_captain_beer_ 111",
-        "message":"Great. Report back to me when you have learnt something usefull."
+        "id":"ff_captain_beer_111",
+        "message":"Great. Report back to me when you have learnt something useful."
     },
     {
         "id":"ff_captain_selector",
@@ -6361,7 +6361,7 @@
         "switchToNPC":"sull_ravine_grazia"
     },
     {
-        "id":"sull_ravine_south of bridge",
+        "id":"sull_ravine_south_of_bridge",
         "rewards":[
             {
                 "rewardType":"questProgress",

--- a/AndorsTrail/res/raw/conversationlist_v0612graves.json
+++ b/AndorsTrail/res/raw/conversationlist_v0612graves.json
@@ -299,21 +299,5 @@
                 "value":72
             }
         ]
-    },
-    {
-        "id":"",
-        "message":"You place the ladder below the tiny window.",
-        "rewards":[
-            {
-                "rewardType":"removeQuestProgress",
-                "rewardID":"feygard_nondisplayed",
-                "value":71
-            },
-            {
-                "rewardType":"questProgress",
-                "rewardID":"feygard_nondisplayed",
-                "value":72
-            }
-        ]
     }
 ]

--- a/AndorsTrail/res/raw/questlist_arulir_mountain.json
+++ b/AndorsTrail/res/raw/questlist_arulir_mountain.json
@@ -146,8 +146,8 @@
         ]
     },
     {
-        "id":"misc_nondisplay ",
-        "name":"misc_nondisplay ",
+        "id":"misc_nondisplay",
+        "name":"misc_nondisplay",
         "stages":[
             {
                 "progress":10,

--- a/AndorsTrail/res/xml/brightport_jail.tmx
+++ b/AndorsTrail/res/xml/brightport_jail.tmx
@@ -251,7 +251,7 @@
  <objectgroup id="9" name="Keys">
   <object id="8" name="escape" type="key" x="448" y="96" width="32" height="32">
    <properties>
-    <property name="phrase" value="brightport_nothing "/>
+    <property name="phrase" value="brightport_nothing"/>
     <property name="requireId" value="brightport_nondisplay"/>
     <property name="requireType" value="questProgress"/>
     <property name="requireValue" value="160"/>

--- a/AndorsTrail/res/xml/way_to_sullengard_east4_bridge.tmx
+++ b/AndorsTrail/res/xml/way_to_sullengard_east4_bridge.tmx
@@ -245,7 +245,7 @@
     <property name="place" value="west"/>
    </properties>
   </object>
-  <object id="8" name="sull_ravine_south of bridge" type="script" x="352" y="736" width="32" height="32">
+  <object id="8" name="sull_ravine_south_of_bridge" type="script" x="352" y="736" width="32" height="32">
    <properties>
     <property name="when" value="enter"/>
    </properties>


### PR DESCRIPTION
This PR fixes several internal ID values in JSON content that contain spaces.  In addition, two cases of invalid ID references have been corrected as well.

One change involves a quest ID (`misc_nondisplay␠` -> `misc_nondisplay`), which is stored in savefiles.   This PR includes an adapter in the savefile load routine for this ID.  New savefiles will be saved with the corrected (spaceless) ID.

**Note:** This PR should be merged AFTER the main content merge from the ATCS Next_Release branch, to prevent any of these changes from being overwritten by content updated there.

### Change Summary
- Removes trailing/leading spaces from IDs and references, including:
  - `brightport_nothing␠`
  - `wexlow_well_throw_oegyth␠_crystal`
  - `ff_captain_beer_␠40`, `␠ff_captain_beer_80`, and `ff_captain_beer_␠111`
  - `sull_ravine_south␠of␠bridge`
  - Updates the corresponding references in other conversations and map.
- Removes trailing space from quest ID `misc_nondisplay␠` in `questlist_arulir_mountain.json`
   - Removed trailing spaces from four corresponding references in conversations.
   - Adds save compatibility: old save files containing `misc_nondisplay␠` are translated to `misc_nondisplay` when loaded; newly saved games use the corrected ID.
- Replaces the invalid faction ID reference `elm2f:_crack` with `elm2f_crack` (should fix a content bug allowing infinite water conversions when intent was to limit to 10; need to test)
- Changes `brightport_crate_success.switchToNPC` from `$playername` to `none`, explicitly clearing the active NPC.
- Removes an empty-ID dialogue entry from `conversationlist_v0612graves.json` (it duplicated previous entry).
- Corrects the typo `usefull` to `useful`.

### Affected content files:
* `AndorsTrail/res/raw/conversationlist_arulir_mountain.json`
* `AndorsTrail/res/raw/conversationlist_brightport.json`
* `AndorsTrail/res/raw/conversationlist_fallhaven_tavern.json`
* `AndorsTrail/res/raw/conversationlist_feygard_1.json`
* `AndorsTrail/res/raw/conversationlist_omi2.json`
* `AndorsTrail/res/raw/conversationlist_omicronrg9.json`
* `AndorsTrail/res/raw/conversationlist_sullengard.json`
* `AndorsTrail/res/raw/conversationlist_v0612graves.json`
* `AndorsTrail/res/raw/questlist_arulir_mountain.json`
* `AndorsTrail/res/xml/brightport_jail.tmx`
* `AndorsTrail/res/xml/way_to_sullengard_east4_bridge.tmx`
