### PR TITLE
Game timer pause/resume refactor

### DIFF
--- a/AndorsTrail/app/build.gradle
+++ b/AndorsTrail/app/build.gradle
@@ -82,6 +82,7 @@ android {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 task copyRes(type: Copy) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
@@ -4,9 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
@@ -73,7 +71,12 @@ public final class Dialogs {
 	 */
 	private static void startBlockingActivityForResult(Activity currentActivity, ControllerContext context, Intent intent, int requestCode) {
 		context.gameRoundController.acquirePause(PauseReason.BLOCKING_ACTIVITY);
-		currentActivity.startActivityForResult(intent, requestCode);
+		try {
+			currentActivity.startActivityForResult(intent, requestCode);
+		} catch (RuntimeException e) {
+			context.gameRoundController.releasePause(PauseReason.BLOCKING_ACTIVITY);
+			throw e;
+		}
 	}
 
 	public static void showMapScriptMessage(final MainActivity currentActivity, final ControllerContext context, String phraseID) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
@@ -37,6 +37,7 @@ import com.gpl.rpg.AndorsTrail.activity.SkillInfoActivity;
 import com.gpl.rpg.AndorsTrail.activity.fragment.StartScreenActivity_MainMenu;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
+import com.gpl.rpg.AndorsTrail.controller.GameRoundController.PauseReason;
 import com.gpl.rpg.AndorsTrail.model.ability.ActorConditionType;
 import com.gpl.rpg.AndorsTrail.model.ability.SkillCollection;
 import com.gpl.rpg.AndorsTrail.model.actor.Monster;
@@ -55,15 +56,24 @@ public final class Dialogs {
 		showDialogAndPause(d, context, null);
 	}
 	private static void showDialogAndPause(CustomDialog d, final ControllerContext context, final OnDismissListener onDismiss) {
-		context.gameRoundController.pause();
+		context.gameRoundController.acquirePause(PauseReason.BLOCKING_DIALOG);
 		CustomDialogFactory.setDismissListener(d, new OnDismissListener() {
 			@Override
 			public void onDismiss(DialogInterface arg0) {
 				if (onDismiss != null) onDismiss.onDismiss(arg0);
-				context.gameRoundController.resume();
+				context.gameRoundController.releasePause(PauseReason.BLOCKING_DIALOG);
 			}
 		});
 		CustomDialogFactory.show(d);
+	}
+
+	/**
+	 * Starts a blocking activity and keeps the round timer paused until the
+	 * caller releases the matching UI hold from its activity result callback.
+	 */
+	private static void startBlockingActivityForResult(Activity currentActivity, ControllerContext context, Intent intent, int requestCode) {
+		context.gameRoundController.acquirePause(PauseReason.BLOCKING_ACTIVITY);
+		currentActivity.startActivityForResult(intent, requestCode);
 	}
 
 	public static void showMapScriptMessage(final MainActivity currentActivity, final ControllerContext context, String phraseID) {
@@ -75,12 +85,11 @@ public final class Dialogs {
 	}
 
 	private static void showConversation(final MainActivity currentActivity, final ControllerContext context, final String phraseID, final Monster npc, boolean applyScriptEffectsForFirstPhrase) {
-		context.gameRoundController.pause();
 		Intent intent = new Intent(currentActivity, ConversationActivity.class);
 		intent.setData(Uri.parse("content://com.gpl.rpg.AndorsTrail/conversation/" + phraseID));
 		intent.putExtra("applyScriptEffectsForFirstPhrase", applyScriptEffectsForFirstPhrase);
 		addMonsterIdentifiers(intent, npc);
-		currentActivity.startActivityForResult(intent, MainActivity.INTENTREQUEST_CONVERSATION);
+		startBlockingActivityForResult(currentActivity, context, intent, MainActivity.INTENTREQUEST_CONVERSATION);
 	}
 
 	public static void addMonsterIdentifiers(Intent intent, Monster monster) {
@@ -106,11 +115,10 @@ public final class Dialogs {
 	}
 
 	public static void showMonsterEncounter(final MainActivity currentActivity, final ControllerContext context, final Monster monster) {
-		context.gameRoundController.pause();
 		Intent intent = new Intent(currentActivity, MonsterEncounterActivity.class);
 		intent.setData(Uri.parse("content://com.gpl.rpg.AndorsTrail/monsterencounter"));
 		addMonsterIdentifiers(intent, monster);
-		currentActivity.startActivityForResult(intent, MainActivity.INTENTREQUEST_MONSTERENCOUNTER);
+		startBlockingActivityForResult(currentActivity, context, intent, MainActivity.INTENTREQUEST_MONSTERENCOUNTER);
 	}
 
 	public static void showMonsterInfo(final Context context, final Monster monster) {
@@ -373,20 +381,18 @@ public final class Dialogs {
 			CustomDialogFactory.addButton(d, android.R.string.ok, new View.OnClickListener() {
 				@Override
 				public void onClick(View v) {
-					controllerContext.gameRoundController.pause();
 					Intent intent = new Intent(mainActivity, LoadSaveActivity.class);
 					intent.setData(Uri.parse("content://com.gpl.rpg.AndorsTrail/save"));
-					mainActivity.startActivityForResult(intent, MainActivity.INTENTREQUEST_SAVEGAME);
+					startBlockingActivityForResult(mainActivity, controllerContext, intent, MainActivity.INTENTREQUEST_SAVEGAME);
 				}
 			});
 			CustomDialogFactory.addDismissButton(d, android.R.string.cancel);
 			CustomDialogFactory.show(d);
 			return false;
 		} else {
-			controllerContext.gameRoundController.pause();
 			Intent intent = new Intent(mainActivity, LoadSaveActivity.class);
 			intent.setData(Uri.parse("content://com.gpl.rpg.AndorsTrail/save"));
-			mainActivity.startActivityForResult(intent, MainActivity.INTENTREQUEST_SAVEGAME);
+			startBlockingActivityForResult(mainActivity, controllerContext, intent, MainActivity.INTENTREQUEST_SAVEGAME);
 			return true;
 		}
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
@@ -27,6 +27,7 @@ import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.controller.AttackResult;
 import com.gpl.rpg.AndorsTrail.controller.CombatController;
 import com.gpl.rpg.AndorsTrail.controller.Constants;
+import com.gpl.rpg.AndorsTrail.controller.GameRoundController.PauseReason;
 import com.gpl.rpg.AndorsTrail.controller.InputController;
 import com.gpl.rpg.AndorsTrail.controller.listeners.CombatActionListener;
 import com.gpl.rpg.AndorsTrail.controller.listeners.CombatTurnListener;
@@ -145,6 +146,7 @@ public final class MainActivity
 		super.onActivityResult(requestCode, resultCode, data);
 		switch (requestCode) {
 		case INTENTREQUEST_MONSTERENCOUNTER:
+			controllers.gameRoundController.releasePause(PauseReason.BLOCKING_ACTIVITY);
 			if (resultCode == Activity.RESULT_OK) {
 				controllers.combatController.enterCombat(CombatController.BeginTurnAs.player);
 			} else {
@@ -152,9 +154,11 @@ public final class MainActivity
 			}
 			break;
 		case INTENTREQUEST_CONVERSATION:
+			controllers.gameRoundController.releasePause(PauseReason.BLOCKING_ACTIVITY);
 			controllers.mapController.applyCurrentMapReplacements(getResources(), true);
 			break;
 		case INTENTREQUEST_SAVEGAME:
+			controllers.gameRoundController.releasePause(PauseReason.BLOCKING_ACTIVITY);
 			if (resultCode != Activity.RESULT_OK) break;
 			final int slot = data.getIntExtra("slot", 1);
 			if (save(slot)) {
@@ -189,7 +193,7 @@ public final class MainActivity
 	@Override
 	protected void onPause() {
 		super.onPause();
-		controllers.gameRoundController.pause();
+		controllers.gameRoundController.onMainActivityPaused();
 		controllers.movementController.stopMovement();
 
 		save(Savegames.SLOT_QUICKSAVE);
@@ -202,7 +206,7 @@ public final class MainActivity
 
 		if (world.model.statistics.isDead()) this.finish();
 		else {
-			controllers.gameRoundController.resume();
+			controllers.gameRoundController.onMainActivityResumed();
 			updateStatus();
 		}
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/CombatController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/CombatController.java
@@ -48,6 +48,17 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		player, monsters, continueLastTurn
 	}
 
+	/**
+	 * Restores combat turn handling when the main activity becomes visible
+	 * again while combat is still active.
+	 */
+	public void resumeCombatIfNeeded() {
+		if (!world.model.uiSelections.isMainActivityVisible) return;
+		if (!world.model.uiSelections.isInCombat) return;
+		setCombatSelection(world.model.uiSelections.selectedMonster, world.model.uiSelections.selectedPosition);
+		enterCombat(BeginTurnAs.continueLastTurn);
+	}
+
 	public void enterCombat(BeginTurnAs whoseTurn) {
 		world.model.uiSelections.isInCombat = true;
 		resetCombatState();
@@ -76,9 +87,8 @@ public final class CombatController implements VisualEffectCompletedCallback {
 		}
 		if (pickupLootBags && totalExpThisFight > 0) {
 			controllers.itemController.lootMonsterBags(killedMonsterBags, totalExpThisFight);
-		} else {
-			controllers.gameRoundController.resume();
 		}
+		controllers.gameRoundController.onCombatStateChanged();
 		resetCombatState();
 	}
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -201,7 +201,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 			roundTimer.stop();
 			return;
 		}
-		world.model.uiSelections.isMainActivityVisible = !isPausedFor(PauseReason.ACTIVITY_HIDDEN);
+		world.model.uiSelections.isMainActivityVisible = !hasPauseReasons();
 		if (hasPauseReasons() || world.model.uiSelections.isInCombat) {
 			roundTimer.stop();
 		} else {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -1,22 +1,36 @@
 package com.gpl.rpg.AndorsTrail.controller;
 
+import java.util.EnumSet;
+
+import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.controller.listeners.GameRoundListeners;
 import com.gpl.rpg.AndorsTrail.model.map.MapObject;
+import com.gpl.rpg.AndorsTrail.util.L;
 import com.gpl.rpg.AndorsTrail.util.TimedMessageTask;
 
 public final class GameRoundController implements TimedMessageTask.Callback {
 
+	public enum PauseReason {
+		ACTIVITY_HIDDEN,
+		BLOCKING_DIALOG,
+		BLOCKING_ACTIVITY,
+		MAP_TRANSITION
+	}
+
 	private final ControllerContext controllers;
 	private final WorldContext world;
 	private final TimedMessageTask roundTimer;
+	private final EnumSet<PauseReason> activePauses = EnumSet.noneOf(PauseReason.class);
 	public final GameRoundListeners gameRoundListeners = new GameRoundListeners();
 
 	public GameRoundController(ControllerContext controllers, WorldContext world) {
 		this.controllers = controllers;
 		this.world = world;
 		this.roundTimer = new TimedMessageTask(this, Constants.TICK_DELAY, true);
+		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
+		updateTimerState();
 	}
 
 	private int ticksUntilNextRound = Constants.TICKS_PER_ROUND;
@@ -24,6 +38,8 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 
 	@Override
 	public boolean onTick(TimedMessageTask task) {
+		if (!hasLoadedModel()) return false;
+		if (hasPauseReasons()) return false;
 		if (!world.model.uiSelections.isMainActivityVisible) return false;
 		if (world.model.uiSelections.isInCombat) return false;
 
@@ -49,14 +65,62 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 		restartWaitForNextFullRound();
 	}
 
-	public void resume() {
-		world.model.uiSelections.isMainActivityVisible = true;
-		roundTimer.start();
-
-		if (world.model.uiSelections.isInCombat) {
-			controllers.combatController.setCombatSelection(world.model.uiSelections.selectedMonster, world.model.uiSelections.selectedPosition);
-			controllers.combatController.enterCombat(CombatController.BeginTurnAs.continueLastTurn);
+	/**
+	 * Marks the supplied pause reason as active.
+	 * In development builds, acquiring the same reason twice is treated as a bug.
+	 */
+	public void acquirePause(PauseReason reason) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			if (activePauses.contains(reason)) {
+				String message = "GameRoundController: duplicate acquire for " + reason;
+				L.error(message);
+				throw new AssertionError(message);
+			}
 		}
+		activePauses.add(reason);
+		updateTimerState();
+	}
+
+	/**
+	 * Clears the supplied pause reason.
+	 * Unmatched releases are logged and ignored so the timer cannot be
+	 * restarted by accident.
+	 */
+	public void releasePause(PauseReason reason) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			if (!activePauses.contains(reason)) {
+				String message = "GameRoundController: unmatched release for " + reason;
+				L.error(message);
+				throw new AssertionError(message);
+			}
+		}
+		activePauses.remove(reason);
+		updateTimerState();
+	}
+
+	/**
+	 * Marks the gameplay activity as hidden and stops the round timer until the
+	 * activity becomes visible again.  This is called when Android pauses the main activity,
+	 * such as when the user switches to another app or the device goes to sleep.
+	 */
+	public void onMainActivityPaused() {
+		acquirePause(PauseReason.ACTIVITY_HIDDEN);
+	}
+
+	/**
+	 * Clears the activity-hidden pause and restores combat state if the player
+	 * is returning to an in-progress combat session.
+	 */
+	public void onMainActivityResumed() {
+		releasePause(PauseReason.ACTIVITY_HIDDEN);
+		controllers.combatController.resumeCombatIfNeeded();
+	}
+
+	/**
+	 * Recomputes whether the round timer should run after combat state changes.
+	 */
+	public void onCombatStateChanged() {
+		updateTimerState();
 	}
 
 	private void restartWaitForNextFullRound() {
@@ -67,9 +131,39 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 		ticksUntilNextRound = Constants.TICKS_PER_ROUND;
 	}
 
-	public void pause() {
-		roundTimer.stop();
-		world.model.uiSelections.isMainActivityVisible = false;
+	/**
+	 * Returns whether any pause reason is currently holding the round timer.
+	 */
+	private boolean hasPauseReasons() {
+		return !activePauses.isEmpty();
+	}
+
+	/**
+	 * Returns whether the supplied pause reason is currently active.
+	 */
+	private boolean isPausedFor(PauseReason reason) {
+		return activePauses.contains(reason);
+	}
+
+	private boolean hasLoadedModel() {
+		return world.model != null && world.model.uiSelections != null;
+	}
+
+	/**
+	 * Synchronizes the derived visibility flag and the round timer with the
+	 * current pause reasons and combat state.
+	 */
+	private void updateTimerState() {
+		if (!hasLoadedModel()) {
+			roundTimer.stop();
+			return;
+		}
+		world.model.uiSelections.isMainActivityVisible = !isPausedFor(PauseReason.ACTIVITY_HIDDEN);
+		if (hasPauseReasons() || world.model.uiSelections.isInCombat) {
+			roundTimer.stop();
+		} else {
+			roundTimer.start();
+		}
 	}
 
 	public void onNewFullRound() {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -12,6 +12,35 @@ import com.gpl.rpg.AndorsTrail.util.TimedMessageTask;
 
 public final class GameRoundController implements TimedMessageTask.Callback {
 
+	/**
+	 * Minimal timer abstraction used to swap in a fake timer from unit tests.
+	 */
+	interface RoundTimer {
+		void start();
+		void stop();
+	}
+
+	/**
+	 * Production timer implementation backed by {@link TimedMessageTask}.
+	 */
+	private static final class TimedRoundTimer implements RoundTimer {
+		private final TimedMessageTask task;
+
+		private TimedRoundTimer(TimedMessageTask task) {
+			this.task = task;
+		}
+
+		@Override
+		public void start() {
+			task.start();
+		}
+
+		@Override
+		public void stop() {
+			task.stop();
+		}
+	}
+
 	public enum PauseReason {
 		ACTIVITY_HIDDEN,
 		BLOCKING_DIALOG,
@@ -21,14 +50,28 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 
 	private final ControllerContext controllers;
 	private final WorldContext world;
-	private final TimedMessageTask roundTimer;
+	private final RoundTimer roundTimer;
 	private final EnumSet<PauseReason> activePauses = EnumSet.noneOf(PauseReason.class);
 	public final GameRoundListeners gameRoundListeners = new GameRoundListeners();
 
+	/**
+	 * Creates the controller with the normal timed-task based round timer.
+	 */
 	public GameRoundController(ControllerContext controllers, WorldContext world) {
 		this.controllers = controllers;
 		this.world = world;
-		this.roundTimer = new TimedMessageTask(this, Constants.TICK_DELAY, true);
+		this.roundTimer = new TimedRoundTimer(new TimedMessageTask(this, Constants.TICK_DELAY, true));
+		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
+		updateTimerState();
+	}
+
+	/**
+	 * Test-only constructor that allows the round timer implementation to be replaced.
+	 */
+	GameRoundController(ControllerContext controllers, WorldContext world, RoundTimer roundTimer) {
+		this.controllers = controllers;
+		this.world = world;
+		this.roundTimer = roundTimer;
 		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
 		updateTimerState();
 	}
@@ -83,8 +126,8 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 
 	/**
 	 * Clears the supplied pause reason.
-	 * Unmatched releases are logged and ignored so the timer cannot be
-	 * restarted by accident.
+	 * Unmatched releases fail fast in development builds and are otherwise
+	 * logged and ignored so the timer cannot be restarted by accident.
 	 */
 	public void releasePause(PauseReason reason) {
 		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ItemController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/ItemController.java
@@ -123,7 +123,6 @@ public final class ItemController {
 			controllers.mapController.worldEventListeners.onPlayerPickedUpMonsterLoot(killedMonsterBags, totalExpThisFight);
 			pickupAll(killedMonsterBags);
 			removeLootBagIfEmpty(killedMonsterBags);
-			controllers.gameRoundController.resume();
 		} else {
 			controllers.mapController.worldEventListeners.onPlayerFoundMonsterLoot(killedMonsterBags, totalExpThisFight);
 			consumeNonItemLoot(killedMonsterBags);

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -6,6 +6,7 @@ import android.os.AsyncTask;
 import com.gpl.rpg.AndorsTrail.AndorsTrailPreferences;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
 import com.gpl.rpg.AndorsTrail.context.WorldContext;
+import com.gpl.rpg.AndorsTrail.controller.GameRoundController.PauseReason;
 import com.gpl.rpg.AndorsTrail.controller.listeners.PlayerMovementListeners;
 import com.gpl.rpg.AndorsTrail.model.MapBundle;
 import com.gpl.rpg.AndorsTrail.model.ModelContainer;
@@ -58,11 +59,11 @@ public final class MovementController implements TimedMessageTask.Callback {
 				super.onPostExecute(result);
 				stopMovement();
 				playerMovementListeners.onPlayerEnteredNewMap(world.model.currentMaps.map, world.model.player.position);
-				controllers.gameRoundController.resume();
+				controllers.gameRoundController.releasePause(PauseReason.MAP_TRANSITION);
 			}
 
 		};
-		controllers.gameRoundController.pause();
+		controllers.gameRoundController.acquirePause(PauseReason.MAP_TRANSITION);
 		task.execute();
 	}
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -45,11 +45,18 @@ public final class MovementController implements TimedMessageTask.Callback {
 	public void placePlayerAsyncAt(final MapObject.MapObjectType objectType, final String mapName, final String placeName, final int offset_x, final int offset_y) {
 
 		AsyncTask<Void, Void, Void> task = new AsyncTask<Void, Void, Void>() {
+			private boolean mapLoadFailed = false;  // (1) flag to carry failure to onPostExecute
+
 			@Override
 			protected Void doInBackground(Void... arg0) {
 				stopMovement();
 
-				placePlayerAt(controllers.getResources(), objectType, mapName, placeName, offset_x, offset_y);
+				try {
+					placePlayerAt(controllers.getResources(), objectType, mapName, placeName, offset_x, offset_y);
+				} catch (RuntimeException e) {
+					L.error("Map transition failed: " + e.getMessage());  // (2) log it
+					mapLoadFailed = true;                                  // (3) signal failure
+				}
 
 				return null;
 			}
@@ -58,11 +65,16 @@ public final class MovementController implements TimedMessageTask.Callback {
 			protected void onPostExecute(Void result) {
 				super.onPostExecute(result);
 				stopMovement();
-				playerMovementListeners.onPlayerEnteredNewMap(world.model.currentMaps.map, world.model.player.position);
+				// (4) always release the pause — timer can never get stuck
 				controllers.gameRoundController.releasePause(PauseReason.MAP_TRANSITION);
+				if (!mapLoadFailed) {
+					playerMovementListeners.onPlayerEnteredNewMap(
+							world.model.currentMaps.map, world.model.player.position);
+				}
 			}
 
 		};
+
 		controllers.gameRoundController.acquirePause(PauseReason.MAP_TRANSITION);
 		task.execute();
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/util/L.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/util/L.java
@@ -7,9 +7,38 @@ import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
 public final class L {
 	private static final String TAG = "AndorsTrail";
 
-	public static void log(String s) {
+	public static void debug(String s) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			Log.d(TAG, s);
+		}
+	}
+
+	public static void info(String s) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			Log.i(TAG, s);
+		}
+	}
+
+	public static void warn(String s) {
 		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
 			Log.w(TAG, s);
 		}
 	}
+
+	public static void error(String s) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			Log.e(TAG, s);
+		}
+	}
+
+	public static void error(String s, Throwable t) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			Log.e(TAG, s, t);
+		}
+	}
+
+	public static void log(String s) {
+		warn(s);
+	}
+
 }

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/util/L.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/util/L.java
@@ -27,13 +27,22 @@ public final class L {
 
 	public static void error(String s) {
 		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-			Log.e(TAG, s);
+			try {
+				Log.e(TAG, s);
+			} catch (RuntimeException e) {
+				System.err.println(TAG + " ERROR: " + s);
+			}
 		}
 	}
 
 	public static void error(String s, Throwable t) {
 		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-			Log.e(TAG, s, t);
+			try {
+				Log.e(TAG, s, t);
+			} catch (RuntimeException e) {
+				System.err.println(TAG + " ERROR: " + s);
+				t.printStackTrace(System.err);
+			}
 		}
 	}
 

--- a/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
+++ b/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
@@ -1,0 +1,126 @@
+package com.gpl.rpg.AndorsTrail.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.gpl.rpg.AndorsTrail.context.WorldContext;
+import com.gpl.rpg.AndorsTrail.model.ModelContainer;
+
+public final class GameRoundControllerTest {
+
+	private static final class FakeRoundTimer implements GameRoundController.RoundTimer {
+		private int startCount = 0;
+		private int stopCount = 0;
+		private boolean running = false;
+
+		@Override
+		public void start() {
+			startCount++;
+			running = true;
+		}
+
+		@Override
+		public void stop() {
+			stopCount++;
+			running = false;
+		}
+	}
+
+	private static GameRoundController createController(WorldContext world, FakeRoundTimer timer) {
+		return new GameRoundController(null, world, timer);
+	}
+
+	private static WorldContext createLoadedWorld() {
+		WorldContext world = new WorldContext();
+		world.model = new ModelContainer(1, true);
+		return world;
+	}
+
+	@Test
+	public void constructorIsSafeBeforeModelLoads() {
+		WorldContext world = new WorldContext();
+		FakeRoundTimer timer = new FakeRoundTimer();
+
+		GameRoundController controller = createController(world, timer);
+
+		assertFalse(controller.onTick(null));
+		assertEquals(0, timer.startCount);
+		assertEquals(1, timer.stopCount);
+		assertFalse(timer.running);
+	}
+
+	@Test
+	public void releasingActivityHiddenStartsTimerWhenNoOtherPauseExists() {
+		WorldContext world = createLoadedWorld();
+		FakeRoundTimer timer = new FakeRoundTimer();
+		GameRoundController controller = createController(world, timer);
+
+		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+
+		assertTrue(world.model.uiSelections.isMainActivityVisible);
+		assertEquals(1, timer.startCount);
+		assertTrue(timer.running);
+	}
+
+	@Test
+	public void mapTransitionReleaseDoesNotRestartTimerWhileBlockingActivityIsActive() {
+		WorldContext world = createLoadedWorld();
+		FakeRoundTimer timer = new FakeRoundTimer();
+		GameRoundController controller = createController(world, timer);
+		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+
+		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_ACTIVITY);
+		controller.acquirePause(GameRoundController.PauseReason.MAP_TRANSITION);
+		controller.releasePause(GameRoundController.PauseReason.MAP_TRANSITION);
+
+		assertFalse(timer.running);
+		assertEquals(1, timer.startCount);
+		assertEquals(4, timer.stopCount);
+
+		controller.releasePause(GameRoundController.PauseReason.BLOCKING_ACTIVITY);
+
+		assertTrue(timer.running);
+		assertEquals(2, timer.startCount);
+	}
+
+	@Test
+	public void combatStateChangeStopsAndRestartsTimer() {
+		WorldContext world = createLoadedWorld();
+		FakeRoundTimer timer = new FakeRoundTimer();
+		GameRoundController controller = createController(world, timer);
+		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+
+		world.model.uiSelections.isInCombat = true;
+		controller.onCombatStateChanged();
+		assertFalse(timer.running);
+
+		world.model.uiSelections.isInCombat = false;
+		controller.onCombatStateChanged();
+		assertTrue(timer.running);
+		assertEquals(2, timer.startCount);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void duplicateAcquireFailsFastInDebugBuilds() {
+		WorldContext world = createLoadedWorld();
+		FakeRoundTimer timer = new FakeRoundTimer();
+		GameRoundController controller = createController(world, timer);
+		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+
+		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
+		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void unmatchedReleaseFailsFastInDebugBuilds() {
+		WorldContext world = createLoadedWorld();
+		FakeRoundTimer timer = new FakeRoundTimer();
+		GameRoundController controller = createController(world, timer);
+		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+
+		controller.releasePause(GameRoundController.PauseReason.MAP_TRANSITION);
+	}
+}

--- a/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
+++ b/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
@@ -103,6 +103,24 @@ public final class GameRoundControllerTest {
 		assertEquals(2, timer.startCount);
 	}
 
+	@Test
+	public void blockingDialogClearsMainActivityVisibilityUntilReleased() {
+		WorldContext world = createLoadedWorld();
+		FakeRoundTimer timer = new FakeRoundTimer();
+		GameRoundController controller = createController(world, timer);
+		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+
+		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
+
+		assertFalse(world.model.uiSelections.isMainActivityVisible);
+		assertFalse(timer.running);
+
+		controller.releasePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
+
+		assertTrue(world.model.uiSelections.isMainActivityVisible);
+		assertTrue(timer.running);
+	}
+
 	@Test(expected = AssertionError.class)
 	public void duplicateAcquireFailsFastInDebugBuilds() {
 		WorldContext world = createLoadedWorld();


### PR DESCRIPTION
This pull request refactors the game round timer and pause management system in AndorsTrail to support multiple simultaneous pause reasons, improving reliability and maintainability. It replaces the previous simple pause/resume logic with a robust, reason-based model, ensuring that the round timer only runs when appropriate and that all gameplay interruptions (dialogs, activities, map transitions, etc.) are properly tracked and released. Additionally, the logging utility is enhanced for better debugging, and unit testing support is improved.

**Game round timer and pause management improvements:**

* Refactored `GameRoundController` to use an `EnumSet<PauseReason>` for tracking multiple simultaneous pause reasons, replacing the old `pause()`/`resume()` methods with `acquirePause(PauseReason)` and `releasePause(PauseReason)`. The timer now only runs when no pause reasons are active, preventing accidental resume during nested pauses. [[1]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R3-R85) [[2]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5L52-R166) [[3]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5L70-R209)
* Updated all code that previously called `pause()`/`resume()` to use the new `acquirePause()`/`releasePause()` methods with appropriate reasons (dialogs, activities, map transitions, etc.), ensuring that all gameplay interruptions are correctly handled. [[1]](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0L58-R78) [[2]](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0L78-R92) [[3]](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0L109-R121) [[4]](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0L376-R395) [[5]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfL61-R66) [[6]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430R149-R161)
* Added `onMainActivityPaused()` and `onMainActivityResumed()` to `GameRoundController` for handling activity lifecycle events, and updated `MainActivity` to use these methods instead of direct pause/resume calls. [[1]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430L192-R196) [[2]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430L205-R209) [[3]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5L52-R166)
* Improved support for unit testing by introducing a `RoundTimer` interface and a test-only constructor in `GameRoundController` to allow swapping in a fake timer.

**Combat and movement state handling:**

* Added `resumeCombatIfNeeded()` to `CombatController` to restore combat state when the main activity is resumed, and ensured that the round timer state is updated when combat ends. [[1]](diffhunk://#diff-d2fb07177a8d49333af2a277a1de7c47de03432860059b07000447ce82cc2614R51-R61) [[2]](diffhunk://#diff-d2fb07177a8d49333af2a277a1de7c47de03432860059b07000447ce82cc2614L79-R91)
* Updated `MovementController` to use the new pause reason system for map transitions, ensuring the timer is paused during transitions and only resumed when safe.

**Logging and debugging improvements:**

* Enhanced the `L` logging utility with new methods (`debug`, `info`, `warn`, `error`) for better debug output, and improved error handling in logging.

**Testing support:**

* Added `testImplementation 'junit:junit:4.13.2'` to `build.gradle` to support unit testing.