### PR TITLE
Fix race condition in "rest" and import/overwrite dialogs

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.java
@@ -3,6 +3,7 @@ package com.gpl.rpg.AndorsTrail;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import android.app.Activity;
 import android.content.Context;
@@ -58,8 +59,8 @@ public final class Dialogs {
 		CustomDialogFactory.setDismissListener(d, new OnDismissListener() {
 			@Override
 			public void onDismiss(DialogInterface arg0) {
-				if (onDismiss != null) onDismiss.onDismiss(arg0);
 				context.gameRoundController.releasePause(PauseReason.BLOCKING_DIALOG);
+				if (onDismiss != null) onDismiss.onDismiss(arg0);
 			}
 		});
 		CustomDialogFactory.show(d);
@@ -297,17 +298,17 @@ public final class Dialogs {
 				currentActivity.getResources().getString(R.string.dialog_rest_confirm_message), 
 				null, 
 				true);
+		final AtomicBoolean confirmed = new AtomicBoolean(false);
 
-		CustomDialogFactory.addButton(d, android.R.string.yes, new View.OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				controllerContext.mapController.rest(area);
-			}
-		});
+		CustomDialogFactory.addButton(d, android.R.string.yes, v -> confirmed.set(true));
 
 		CustomDialogFactory.addDismissButton(d, android.R.string.no);
 
-		showDialogAndPause(d, controllerContext);
+		showDialogAndPause(d, controllerContext, arg0 -> {
+			if (confirmed.get()) {
+				controllerContext.mapController.rest(area);
+			}
+		});
 	}
 	public static void showRested(final Activity currentActivity, final ControllerContext controllerContext) {
 		//		Dialog d = new AlertDialog.Builder(new ContextThemeWrapper(currentActivity, R.style.AndorsTrailStyle))

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadSaveActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadSaveActivity.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import android.Manifest;
 import android.app.Activity;
@@ -786,27 +787,32 @@ public final class LoadSaveActivity extends AndorsTrailBaseActivity implements O
                                                                    true,
                                                                    false,
                                                                    true);
+            final AtomicBoolean proceed = new AtomicBoolean(false);
 
             CustomDialogFactory.addButton(dialog, R.string.loadsave_import_option_keep_existing, v -> {
-                //do nothing
-                GoToNextConflictOrFinish(resolver, appSavegameFolder, newFiles, dialogs);
+                proceed.set(true);
             });
 
             CustomDialogFactory.addButton(dialog, R.string.loadsave_import_option_keep_imported, v -> {
                 newFiles.add(alreadyExistingFile);
-                GoToNextConflictOrFinish(resolver, appSavegameFolder, newFiles, dialogs);
+                proceed.set(true);
             });
 
             CustomDialogFactory.addButton(dialog, R.string.loadsave_import_option_add_as_new, v -> {
                 newFiles.add(null);//add a null element as marker to know later if the next file
                 // should be imported as new or overwrite the existing one
                 newFiles.add(alreadyExistingFile);
-                GoToNextConflictOrFinish(resolver, appSavegameFolder, newFiles, dialogs);
+                proceed.set(true);
             });
 
             CustomDialogFactory.addCancelButton(dialog, android.R.string.cancel);
             CustomDialogFactory.setCancelListener(dialog, v -> {
                 completeLoadSaveActivity(SLOT_NUMBER_IMPORT_SAVEGAMES, false);
+            });
+            CustomDialogFactory.setDismissListener(dialog, dialogInterface -> {
+                if (proceed.get()) {
+                    GoToNextConflictOrFinish(resolver, appSavegameFolder, newFiles, dialogs);
+                }
             });
 
             dialogs.add(dialog);


### PR DESCRIPTION
This pull request refactors dialog button handling in `Dialogs.java` and `LoadSaveActivity.java` to ensure that critical actions are only performed after dialogs are fully dismissed, rather than immediately on button press. This change improves UI consistency and prevents potential issues from actions running before the dialog is closed.

**Dialog button handling improvements:**

* In `Dialogs.java`, the confirmation for resting now sets a flag on button press and performs the rest action only after the dialog is dismissed, using an `AtomicBoolean` to track confirmation. (`[AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.javaR301-R311](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0R301-R311)`)
* In `LoadSaveActivity.java`, all import conflict resolution options now set a flag on button press and proceed to the next step only after the dialog is dismissed, ensuring dialog state is properly handled. (`[AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadSaveActivity.javaR790-R816](diffhunk://#diff-ef5f48a745d249679632cbc3c2860703307648b8ad75bd92622a5e1bb631011cR790-R816)`)

**Code structure and safety:**

* Introduced `AtomicBoolean` in both files to safely track user confirmation across dialog lifecycle events. (`[[1]](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0R301-R311)`, `[[2]](diffhunk://#diff-ef5f48a745d249679632cbc3c2860703307648b8ad75bd92622a5e1bb631011cR790-R816)`, `[[3]](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0R6)`, `[[4]](diffhunk://#diff-ef5f48a745d249679632cbc3c2860703307648b8ad75bd92622a5e1bb631011cR12)`)
* Adjusted the order of operations in dialog dismiss listeners to ensure game state is updated before custom dismiss logic is executed. (`[AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/Dialogs.javaL61-R63](diffhunk://#diff-81d1904672702a5c5832ffc9a20e52e8b9ecbf63c08ac8d9d75d10cf417195e0L61-R63)`)