### PR TITLE
Fix race condition in player respawn logic for NPCs

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
@@ -134,7 +134,9 @@ public final class MapController {
 		if (!world.model.statistics.isDead()) {
 			lotsOfTimePassed(); // Do BEFORE calling async task to avoid racing with respawn
 			controllers.movementController.respawnPlayerAsync();
-			// Run check for achievements - AFTER respawn is called so any dialogue appears over bed map
+			// Run check for achievements - AFTER respawn is called so any dialogue appears over bed map.
+			// NOTE: Current map is indeterminate at the time achievement script runs.  Do not use map-dependent
+			// requirement types/rewards in passive_achievement_check scripts. (spawnAll, mapChange, etc).
 			mapScriptExecutor.proceedToPhrase(controllers.getResources(), Constants.PASSIVE_ACHIEVEMENT_CHECK_PHRASE, true, true);
 		}
 		worldEventListeners.onPlayerDied(lostExp);

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
@@ -132,12 +132,18 @@ public final class MapController {
 		world.model.statistics.addPlayerDeath(lostExp);
 
 		if (!world.model.statistics.isDead()) {
+			lotsOfTimePassed(); // Do BEFORE calling async task to avoid racing with respawn
 			controllers.movementController.respawnPlayerAsync();
-			lotsOfTimePassed();
+			// Run check for achievements - AFTER respawn is called so any dialogue appears over bed map
+			mapScriptExecutor.proceedToPhrase(controllers.getResources(), Constants.PASSIVE_ACHIEVEMENT_CHECK_PHRASE, true, true);
 		}
 		worldEventListeners.onPlayerDied(lostExp);
 	}
 
+	/**
+	 * Resets (despawns) all maps and resets round counters, simulating a lot of time passing during rest and resurrection.
+	 * Does NOT respawn the player or run passive achievement script; this is done by callers
+	 */
 	public void lotsOfTimePassed() {
 		final Player player = world.model.player;
 		controllers.actorStatsController.removeAllTemporaryConditions(player);
@@ -148,14 +154,14 @@ public final class MapController {
 		for (PredefinedMap m : world.maps.getAllMaps()) {
 			m.resetTemporaryData();
 		}
-		controllers.monsterSpawnController.spawnAll(world.model.currentMaps.map, world.model.currentMaps.tileMap);
 		world.model.worldData.tickWorldTime(20);
 		controllers.gameRoundController.resetRoundTimers();
-		mapScriptExecutor.proceedToPhrase(controllers.getResources(), Constants.PASSIVE_ACHIEVEMENT_CHECK_PHRASE, true, true);
 	}
 
 	public void rest(MapObject area) {
-		lotsOfTimePassed();
+		lotsOfTimePassed(); // Despawns all maps
+		controllers.monsterSpawnController.spawnAll(world.model.currentMaps.map, world.model.currentMaps.tileMap);
+		mapScriptExecutor.proceedToPhrase(controllers.getResources(), Constants.PASSIVE_ACHIEVEMENT_CHECK_PHRASE, true, true);
 		world.model.player.setSpawnPlace(world.model.currentMaps.map.name, area.id);
 		worldEventListeners.onPlayerRested();
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MapController.java
@@ -144,7 +144,7 @@ public final class MapController {
 
 	/**
 	 * Resets (despawns) all maps and resets round counters, simulating a lot of time passing during rest and resurrection.
-	 * Does NOT respawn the player or run passive achievement script; this is done by callers
+	 * Does not respawn the player or run the passive achievement script; callers handle that.
 	 */
 	public void lotsOfTimePassed() {
 		final Player player = world.model.player;

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -97,6 +97,7 @@ public final class MovementController implements TimedMessageTask.Callback {
 		}
 		final ModelContainer model = world.model;
 
+		if (model.currentMaps.map != null) model.currentMaps.map.updateLastVisitTime();
 		model.player.position.set(place.position.topLeft);
 		model.player.position.x += Math.min(offset_x, place.position.size.width-1);
 		model.player.position.y += Math.min(offset_y, place.position.size.height-1);
@@ -107,7 +108,6 @@ public final class MovementController implements TimedMessageTask.Callback {
 		}
 
 		prepareMapAsCurrentMap(newMap, res, true);
-
 	}
 
 	private void playerVisitsMapFirstTime(PredefinedMap m) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -79,6 +79,12 @@ public final class MovementController implements TimedMessageTask.Callback {
 		task.execute();
 	}
 
+	/**
+	 * Places the player on a named map object and loads that map as the current map.
+	 *
+	 * <p>The previous map's visit time is refreshed before the transition so it remains
+	 * "recently visited" after leaving.</p>
+	 */
 	public void placePlayerAt(final Resources res, MapObject.MapObjectType objectType, String mapName, String placeName, int offset_x, int offset_y) {
 		if (mapName == null || placeName == null) return;
 		PredefinedMap newMap = world.maps.findPredefinedMap(mapName);
@@ -97,7 +103,6 @@ public final class MovementController implements TimedMessageTask.Callback {
 		}
 		final ModelContainer model = world.model;
 
-		if (model.currentMaps.map != null) model.currentMaps.map.updateLastVisitTime();
 		model.player.position.set(place.position.topLeft);
 		model.player.position.x += Math.min(offset_x, place.position.size.width-1);
 		model.player.position.y += Math.min(offset_y, place.position.size.height-1);
@@ -107,6 +112,9 @@ public final class MovementController implements TimedMessageTask.Callback {
 			playerVisitsMapFirstTime(newMap);
 		}
 
+		// Mark last visit time on current map before leaving it (unless it has been reset because we're in hero respawn)
+		if (model.currentMaps.map != null && !model.currentMaps.map.hasResetTemporaryData()) model.currentMaps.map.updateLastVisitTime();
+
 		prepareMapAsCurrentMap(newMap, res, true);
 	}
 
@@ -115,6 +123,13 @@ public final class MovementController implements TimedMessageTask.Callback {
 		world.maps.worldMapRequiresUpdate = true;
 	}
 
+	/**
+	 * Loads the given map bundle into {@code world.model.currentMaps} and performs the
+	 * follow-up setup needed after a transition.
+	 *
+	 * <p>When {@code spawnMonsters} is true, non-recently-visited maps are repopulated
+	 * before scripts, blocked-actor handling, and visual refreshes run.</p>
+	 */
 	public void prepareMapAsCurrentMap(PredefinedMap newMap, Resources res, boolean spawnMonsters) {
 		final ModelContainer model = world.model;
 		MapBundle newMaps = new MapBundle();

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -97,7 +97,6 @@ public final class MovementController implements TimedMessageTask.Callback {
 		}
 		final ModelContainer model = world.model;
 
-		if (model.currentMaps.map != null) model.currentMaps.map.updateLastVisitTime();
 		model.player.position.set(place.position.topLeft);
 		model.player.position.x += Math.min(offset_x, place.position.size.width-1);
 		model.player.position.y += Math.min(offset_y, place.position.size.height-1);
@@ -108,6 +107,7 @@ public final class MovementController implements TimedMessageTask.Callback {
 		}
 
 		prepareMapAsCurrentMap(newMap, res, true);
+
 	}
 
 	private void playerVisitsMapFirstTime(PredefinedMap m) {


### PR DESCRIPTION
This pull request refactors and clarifies the handling of map resets, monster spawning, and achievement checks during player death and rest events. The main improvements involve separating concerns in the `lotsOfTimePassed` method, ensuring correct event sequencing to avoid race conditions, and making map transition logic more robust and well-documented.

**Map and Event Handling Improvements:**

* The `lotsOfTimePassed` method now only resets maps and round counters; monster spawning and achievement checks are moved out to be explicitly called by the relevant event handlers, reducing side effects and improving clarity. [[1]](diffhunk://#diff-283386bc87f26ff3b96576ca42f5422357440ed6e8c3d8dc88430c97ea0bea5fR135-R148) [[2]](diffhunk://#diff-283386bc87f26ff3b96576ca42f5422357440ed6e8c3d8dc88430c97ea0bea5fL151-R166)
* During player death, `lotsOfTimePassed` is called before respawning to avoid race conditions, and achievement checks are run after respawn to ensure correct dialog timing.
* The `rest` method now explicitly calls `spawnAll` and runs the passive achievement script after resetting maps, making the sequence of events clearer and more predictable.

**Map Transition and Visit Tracking:**

* In `placePlayerAt`, the logic for updating the previous map's last visit time is improved: it now only updates if the map hasn't been reset (e.g., during hero respawn), preventing incorrect visit timestamps. [[1]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfL100) [[2]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfR115-R117)

**Documentation Improvements:**

* Added detailed JavaDoc comments to `placePlayerAt` and `prepareMapAsCurrentMap` to clarify their responsibilities and sequencing, aiding future maintenance and onboarding. [[1]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfR82-R87) [[2]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfR126-R132)