### PR TITLE
fix new game respawn logic by moving respawn call after lotsoftimepassed()

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/WorldSetup.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/WorldSetup.java
@@ -154,9 +154,8 @@ public final class WorldSetup {
 		world.model = new ModelContainer(newHeroStartLives, newHeroUnlimitedSaves);
 		world.model.player.initializeNewPlayer(world.dropLists, newHeroName, newHeroIcon);
 
-		controllers.actorStatsController.recalculatePlayerStats(world.model.player);
-		controllers.movementController.respawnPlayer(ctx.getResources());
 		controllers.mapController.lotsOfTimePassed();
+		controllers.movementController.respawnPlayer(ctx.getResources());
 	}
 
 


### PR DESCRIPTION
This pull request makes a small change to the order of method calls in the `createNewWorld` function. The call to `recalculatePlayerStats` has been removed, and the call to `respawnPlayer` has been moved after `lotsOfTimePassed`.
This prevents NPCs from being wiped after the player (and NPCs) are spawned.

Most important change:

* The call to `controllers.actorStatsController.recalculatePlayerStats` was removed, and `controllers.movementController.respawnPlayer` is now called after `controllers.mapController.lotsOfTimePassed` in the `createNewWorld` method of `WorldSetup.java`.