### PR TITLE
Remove controller line from manifest to fix Play error

### DIFF
--- a/AndorsTrail/app/src/main/AndroidManifest.xml
+++ b/AndorsTrail/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
 
 	<uses-feature android:name="android.software.leanback" android:required="false"/>
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
-	<uses-feature android:name="android.hardware.gamepad" android:required="false" />
 
 	<queries>
 		<intent>


### PR DESCRIPTION
This  PR removes the the explicit declaration for gamepad hardware support.  This is needed because Play treats even optional gamepad declarations as "required" on the TV platform.  Controllers should still work as expected.

* Removed the `<uses-feature android:name="android.hardware.gamepad" android:required="false" />` line from `AndroidManifest.xml`, so the app will not signal to the Play Store or devices that it supports gamepad hardware.…