### PR TITLE
use location-aware parser for bulk selection number field

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/BulkSelectionInterface.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/BulkSelectionInterface.java
@@ -10,6 +10,9 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+import java.util.Locale;
 import com.gpl.rpg.AndorsTrail.util.Format;
 import android.widget.Button;
 import android.widget.EditText;
@@ -306,10 +309,13 @@ public final class BulkSelectionInterface extends AndorsTrailBaseActivity implem
 
 	private int getTextboxAmount() {
 		final String s = bulkselection_amount_taken.getText().toString();
-		if (s.equals("")) return 0;
-		try {
-			return Integer.parseInt(s);
-		} catch (NumberFormatException ignored) { }
+		if (s.isEmpty()) return 0;
+		NumberFormat numberFormat = NumberFormat.getIntegerInstance(Locale.getDefault());
+		ParsePosition parsePosition = new ParsePosition(0);
+		Number parsed = numberFormat.parse(s, parsePosition);
+		if (parsed != null && parsePosition.getIndex() == s.length()) {
+			return parsed.intValue();
+		}
 		return 0;
 	}
 


### PR DESCRIPTION
This pull request updates the way numeric input is parsed in the `BulkSelectionInterface` to improve locale support and input validation. The main change is replacing the previous `Integer.parseInt` approach with a more robust method using `NumberFormat` and `ParsePosition`, ensuring that numbers are parsed correctly according to the user's locale settings and that only fully valid numbers are accepted.

**Input parsing improvements:**
* [`BulkSelectionInterface.java`](diffhunk://#diff-451ce6105e7b7e870a2b515d3bc3858417d6e5df4019d071888092b1c144b49dR13-R15): Replaced direct integer parsing in `getTextboxAmount()` with locale-aware parsing using `NumberFormat` and `ParsePosition`, improving support for different number formats and stricter validation of input. [[1]](diffhunk://#diff-451ce6105e7b7e870a2b515d3bc3858417d6e5df4019d071888092b1c144b49dR13-R15) [[2]](diffhunk://#diff-451ce6105e7b7e870a2b515d3bc3858417d6e5df4019d071888092b1c144b49dL309-R318)