### PR TITLE
Enhance savegame loading error handling and debugging

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
@@ -166,7 +166,7 @@ public final class LoadingActivity extends AndorsTrailBaseActivity implements On
 
 	private void showLoadingFailedDialog(int messageResourceID) {
 		String message = Savegames.getLastLoadFailureMessage();
-		if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA && (message == null || message.isEmpty())) {
+		if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA && message != null && !message.isEmpty()) {
 			message = Savegames.getLastLoadFailureMessage();
 		} else {
 			message = getResources().getString(messageResourceID);

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
@@ -165,7 +165,13 @@ public final class LoadingActivity extends AndorsTrailBaseActivity implements On
 	}
 
 	private void showLoadingFailedDialog(int messageResourceID) {
-		final CustomDialog d = CustomDialogFactory.createDialog(this, getResources().getString(R.string.dialog_loading_failed_title), null, getResources().getString(messageResourceID), null, true);
+		String message = Savegames.getLastLoadFailureMessage();
+		if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA && (message == null || message.isEmpty())) {
+			message = Savegames.getLastLoadFailureMessage();
+		} else {
+			message = getResources().getString(messageResourceID);
+		}
+		final CustomDialog d = CustomDialogFactory.createDialog(this, getResources().getString(R.string.dialog_loading_failed_title), null, message, null, true);
 		CustomDialogFactory.addDismissButton(d, android.R.string.ok);
 		CustomDialogFactory.setDismissListener(d, new OnDismissListener() {
 			@Override
@@ -174,6 +180,6 @@ public final class LoadingActivity extends AndorsTrailBaseActivity implements On
 			}
 		});
 		CustomDialogFactory.show(d);
-		
+
 	}
 }

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/LoadingActivity.java
@@ -167,18 +167,13 @@ public final class LoadingActivity extends AndorsTrailBaseActivity implements On
 	private void showLoadingFailedDialog(int messageResourceID) {
 		String message = Savegames.getLastLoadFailureMessage();
 		if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA && message != null && !message.isEmpty()) {
-			message = Savegames.getLastLoadFailureMessage();
+			message = getResources().getString(R.string.dialog_loading_failed_details, message);
 		} else {
 			message = getResources().getString(messageResourceID);
 		}
 		final CustomDialog d = CustomDialogFactory.createDialog(this, getResources().getString(R.string.dialog_loading_failed_title), null, message, null, true);
 		CustomDialogFactory.addDismissButton(d, android.R.string.ok);
-		CustomDialogFactory.setDismissListener(d, new OnDismissListener() {
-			@Override
-			public void onDismiss(DialogInterface dialog) {
-				LoadingActivity.this.finish();
-			}
-		});
+		CustomDialogFactory.setDismissListener(d, dialog -> LoadingActivity.this.finish());
 		CustomDialogFactory.show(d);
 
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Collections;
 
 import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
@@ -14,6 +15,7 @@ import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.model.ChecksumBuilder;
 import com.gpl.rpg.AndorsTrail.savegames.LegacySavegameFormatReaderForMap;
 import com.gpl.rpg.AndorsTrail.util.L;
+import com.gpl.rpg.AndorsTrail.util.Size;
 
 public final class MapCollection {
 	private final HashMap<String, PredefinedMap> predefinedMaps = new HashMap<String, PredefinedMap>();
@@ -73,12 +75,21 @@ public final class MapCollection {
 			L.debug("MapCollection.readFromParcel: loading map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
 			PredefinedMap map = predefinedMaps.get(name);
 			if (map == null) {
-				throw new IOException("Savegame contains unknown map \"" + name + "\".");
-			}
-			map.readFromParcel(src, world, controllers, fileversion);
-			L.debug("MapCollection.readFromParcel: loaded map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
-			if (i >= 40) {
-				if (fileversion < 15) map.visited = false;
+				// Map not found.  In production mode only, read and discard the missing map.  This should never happen,
+				// because these content bugs should be caught before it goes to prod, but just in case we want
+				// to make sure that the user can still use their savefile if it happens anyway.
+				if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
+					throw new IOException("Savegame contains unknown map \"" + name + "\".");
+				} else {
+					PredefinedMap placeholder = new PredefinedMap(-1, name, new Size(1, 1), new MapObject[0], new MonsterSpawnArea[0], Collections.emptyList(), false, null);
+					placeholder.readFromParcel(src, world, controllers, fileversion);
+				}
+			} else {
+				map.readFromParcel(src, world, controllers, fileversion);
+				L.debug("MapCollection.readFromParcel: loaded map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
+				if (i >= 40) {
+					if (fileversion < 15) map.visited = false;
+				}
 			}
 		}
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
@@ -65,27 +65,18 @@ public final class MapCollection {
 		for(int i = 0; i < size; ++i) {
 			String name;
 			if (fileversion >= 35) {
-				if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-					L.debug("MapCollection.readFromParcel: reading map name for entry " + i + " of " + size + ".");
-				}
+				L.debug("MapCollection.readFromParcel: reading map name for entry " + i + " of " + size + ".");
 				name = src.readUTF();
 			} else {
 				name = LegacySavegameFormatReaderForMap.getMapnameFromIndex(i);
 			}
-			if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-				L.debug("MapCollection.readFromParcel: loading map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
-			}
+			L.debug("MapCollection.readFromParcel: loading map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
 			PredefinedMap map = predefinedMaps.get(name);
 			if (map == null) {
-				if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
-					L.log("WARNING: Tried to load savegame with map \"" + name + "\", but no such map exists.");
-				}
 				throw new IOException("Savegame contains unknown map \"" + name + "\".");
 			}
 			map.readFromParcel(src, world, controllers, fileversion);
-			if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-				L.debug("MapCollection.readFromParcel: loaded map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
-			}
+			L.debug("MapCollection.readFromParcel: loaded map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
 			if (i >= 40) {
 				if (fileversion < 15) map.visited = false;
 			}
@@ -94,9 +85,8 @@ public final class MapCollection {
 
 	public static boolean shouldSaveMap(WorldContext world, PredefinedMap map) {
 		if (map.visited) return true;
-		if (map.shouldSaveMapData(world)) return true;
-		return false;
-	}
+        return map.shouldSaveMapData(world);
+    }
 
 	public void writeToParcel(DataOutputStream dest, WorldContext world) throws IOException {
 		List<PredefinedMap> mapsToExport = new ArrayList<PredefinedMap>();

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
@@ -65,9 +65,15 @@ public final class MapCollection {
 		for(int i = 0; i < size; ++i) {
 			String name;
 			if (fileversion >= 35) {
+				if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+					L.debug("MapCollection.readFromParcel: reading map name for entry " + i + " of " + size + ".");
+				}
 				name = src.readUTF();
 			} else {
 				name = LegacySavegameFormatReaderForMap.getMapnameFromIndex(i);
+			}
+			if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+				L.debug("MapCollection.readFromParcel: loading map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
 			}
 			PredefinedMap map = predefinedMaps.get(name);
 			if (map == null) {
@@ -77,6 +83,9 @@ public final class MapCollection {
 				continue;
 			}
 			map.readFromParcel(src, world, controllers, fileversion);
+			if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+				L.debug("MapCollection.readFromParcel: loaded map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
+			}
 			if (i >= 40) {
 				if (fileversion < 15) map.visited = false;
 			}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
@@ -80,7 +80,7 @@ public final class MapCollection {
 				if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
 					L.log("WARNING: Tried to load savegame with map \"" + name + "\", but no such map exists.");
 				}
-				continue;
+				throw new IOException("Savegame contains unknown map \"" + name + "\".");
 			}
 			map.readFromParcel(src, world, controllers, fileversion);
 			if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/MapCollection.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Collections;
 
 import com.gpl.rpg.AndorsTrail.AndorsTrailApplication;
 import com.gpl.rpg.AndorsTrail.context.ControllerContext;
@@ -15,7 +14,6 @@ import com.gpl.rpg.AndorsTrail.context.WorldContext;
 import com.gpl.rpg.AndorsTrail.model.ChecksumBuilder;
 import com.gpl.rpg.AndorsTrail.savegames.LegacySavegameFormatReaderForMap;
 import com.gpl.rpg.AndorsTrail.util.L;
-import com.gpl.rpg.AndorsTrail.util.Size;
 
 public final class MapCollection {
 	private final HashMap<String, PredefinedMap> predefinedMaps = new HashMap<String, PredefinedMap>();
@@ -75,15 +73,9 @@ public final class MapCollection {
 			L.debug("MapCollection.readFromParcel: loading map \"" + name + "\" (" + (i + 1) + "/" + size + ").");
 			PredefinedMap map = predefinedMaps.get(name);
 			if (map == null) {
-				// Map not found.  In production mode only, read and discard the missing map.  This should never happen,
-				// because these content bugs should be caught before it goes to prod, but just in case we want
-				// to make sure that the user can still use their savefile if it happens anyway.
-				if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
-					throw new IOException("Savegame contains unknown map \"" + name + "\".");
-				} else {
-					PredefinedMap placeholder = new PredefinedMap(-1, name, new Size(1, 1), new MapObject[0], new MonsterSpawnArea[0], Collections.emptyList(), false, null);
-					placeholder.readFromParcel(src, world, controllers, fileversion);
-				}
+				// Savegame contains unknown map, bail out.  This will fail in production too;
+				// a missing map is a critical content bug that should be caught before it goes to prod.
+				throw new IOException("Savegame contains unknown map \"" + name + "\".");
 			} else {
 				map.readFromParcel(src, world, controllers, fileversion);
 				L.debug("MapCollection.readFromParcel: loaded map \"" + name + "\" (" + (i + 1) + "/" + size + ").");

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
@@ -286,12 +286,13 @@ public final class PredefinedMap {
 					} while (j != i);
 					if (!found) {
 						if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
-							L.log("WARNING: Trying to load monsters from savegame in map " + this.name + " for spawn area " + id + " but this area cannot be found. This will totally fail.");
+							L.warn("WARNING: Trying to load monsters from savegame in map " + this.name + " for spawn area " + id + " but this area cannot be found. This will totally fail.");
 							throw new IOException("Savegame contains unknown spawn area \"" + id + "\" in map \"" + this.name + "\".");
 						} else {
 							// In production mode only, read and discard the missing spawn area.  This should never happen,
-							// because these content bugs should be caught before it goes to prod, but at least the user can
-							// still use their savefile.  In almost all cases, this should be harmless.
+							// because these content bugs should be caught before it goes to prod, but just in case we want
+							// to make sure that the user can still use their savefile if it happens anyway.
+							// In almost all cases, this should be harmless to the game state.
 							new MonsterSpawnArea(
 									new CoordRect(new Coord(), new Size(1, 1))
 									, new Range(0, 0)

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
@@ -309,20 +309,8 @@ public final class PredefinedMap {
 							).readFromParcel(src, world, fileversion);
 						}
 					}
-				} else if (i < this.spawnAreas.length) { // fileversion < 43
+				} else {
 					this.spawnAreas[i].readFromParcel(src, world, fileversion);
-				} else { // This should never happen, but is here to handle discarding of spawn areas in missing maps for savefiles <43
-					new MonsterSpawnArea(
-							new CoordRect(new Coord(), new Size(1, 1))
-							, new Range(0, 0)
-							, new Range(0, 0)
-							, ""
-							, new String[0]
-							, false
-							, false
-							, ""
-							, false
-					).readFromParcel(src, world, fileversion);
 				}
 			}
 			

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
@@ -285,7 +285,7 @@ public final class PredefinedMap {
 					} while (j != i);
 					if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
 						if (!found) {
-							L.log("WARNING: Trying to load monsters from savegame in map " + this.name + " for spawn #" + id + " but this area cannot be found. This will totally fail.");
+							L.log("WARNING: Trying to load monsters from savegame in map " + this.name + " for spawn area " + id + " but this area cannot be found. This will totally fail.");
 						}
 					}
 				} else {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
@@ -274,16 +274,19 @@ public final class PredefinedMap {
 				if(fileversion >= 43) {
 					//Spawn areas now have unique IDs. Need to check as maps can change.
 					String id = src.readUTF();
-					int j = i;
 					boolean found = false;
-					do {
-						if (this.spawnAreas[j].areaID.equals(id)) {
-							this.spawnAreas[j].readFromParcel(src, world, fileversion);
-							found = true;
-							break;
-						} 
-						j = (j+1)%spawnAreas.length;
-					} while (j != i);
+					if (this.spawnAreas.length > 0) {
+						int start = i % this.spawnAreas.length;
+						int j = start;
+						do {
+							if (this.spawnAreas[j].areaID.equals(id)) {
+								this.spawnAreas[j].readFromParcel(src, world, fileversion);
+								found = true;
+								break;
+							}
+							j = (j + 1) % this.spawnAreas.length;
+						} while (j != start);
+					}
 					if (!found) {
 						if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
 							L.warn("WARNING: Trying to load monsters from savegame in map " + this.name + " for spawn area " + id + " but this area cannot be found. This will totally fail.");

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
@@ -20,6 +20,7 @@ import com.gpl.rpg.AndorsTrail.model.map.MapObject.MapObjectType;
 import com.gpl.rpg.AndorsTrail.util.Coord;
 import com.gpl.rpg.AndorsTrail.util.CoordRect;
 import com.gpl.rpg.AndorsTrail.util.L;
+import com.gpl.rpg.AndorsTrail.util.Range;
 import com.gpl.rpg.AndorsTrail.util.Size;
 
 public final class PredefinedMap {
@@ -283,9 +284,25 @@ public final class PredefinedMap {
 						} 
 						j = (j+1)%spawnAreas.length;
 					} while (j != i);
-					if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
-						if (!found) {
+					if (!found) {
+						if (AndorsTrailApplication.DEVELOPMENT_VALIDATEDATA) {
 							L.log("WARNING: Trying to load monsters from savegame in map " + this.name + " for spawn area " + id + " but this area cannot be found. This will totally fail.");
+							throw new IOException("Savegame contains unknown spawn area \"" + id + "\" in map \"" + this.name + "\".");
+						} else {
+							// In production mode only, read and discard the missing spawn area.  This should never happen,
+							// because these content bugs should be caught before it goes to prod, but at least the user can
+							// still use their savefile.  In almost all cases, this should be harmless.
+							new MonsterSpawnArea(
+									new CoordRect(new Coord(), new Size(1, 1))
+									, new Range(0, 0)
+									, new Range(0, 0)
+									, id
+									, new String[0]
+									, false
+									, false
+									, ""
+									, false
+							).readFromParcel(src, world, fileversion);
 						}
 					}
 				} else {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/model/map/PredefinedMap.java
@@ -309,8 +309,20 @@ public final class PredefinedMap {
 							).readFromParcel(src, world, fileversion);
 						}
 					}
-				} else {
+				} else if (i < this.spawnAreas.length) { // fileversion < 43
 					this.spawnAreas[i].readFromParcel(src, world, fileversion);
+				} else { // This should never happen, but is here to handle discarding of spawn areas in missing maps for savefiles <43
+					new MonsterSpawnArea(
+							new CoordRect(new Coord(), new Size(1, 1))
+							, new Range(0, 0)
+							, new Range(0, 0)
+							, ""
+							, new String[0]
+							, false
+							, false
+							, ""
+							, false
+					).readFromParcel(src, world, fileversion);
 				}
 			}
 			

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
@@ -49,6 +49,8 @@ public final class Savegames {
 		, cheatingDetected
 	}
 
+	private static String lastLoadFailureMessage = null;
+
 	public static boolean saveWorld(WorldContext world, Context androidContext, int slot) {
 		try {
 			final String displayInfo = androidContext.getString(R.string.savegame_currenthero_displayinfo, world.model.player.getLevel(), world.model.player.getTotalExperience(), world.model.player.getGold());
@@ -96,6 +98,7 @@ public final class Savegames {
 	}
 
 	public static LoadSavegameResult loadWorld(WorldContext world, ControllerContext controllers, Context androidContext, int slot) {
+		lastLoadFailureMessage = null;
 		try {
 			FileHeader fh = quickload(androidContext, slot);
 			if(fh == null) {
@@ -112,6 +115,7 @@ public final class Savegames {
 			try {
 				result = loadWorld(androidContext.getResources(), world, controllers, androidContext, fos, fh);
 			} catch (IOException | DigestException e) {
+				lastLoadFailureMessage = e.getMessage() != null ? e.getMessage() : e.toString();
 				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded from " + fh.describe() + ".", e);
 				return LoadSavegameResult.unknownError;
 			} finally {
@@ -135,9 +139,14 @@ public final class Savegames {
 			}
 			return result;
 		} catch (IOException e) {
+			lastLoadFailureMessage = e.getMessage() != null ? e.getMessage() : e.toString();
 			debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file or scene cannot be loaded.", e);
 			return LoadSavegameResult.unknownError;
 		}
+	}
+
+	public static String getLastLoadFailureMessage() {
+		return lastLoadFailureMessage;
 	}
 
 	private static void debugLoadFailure(String message) {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
@@ -102,11 +102,11 @@ public final class Savegames {
 		try {
 			FileHeader fh = quickload(androidContext, slot);
 			if(fh == null) {
-				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded because it is missing or unreadable.");
+				L.warn("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded because it is missing or unreadable.");
 				return LoadSavegameResult.unknownError;
 			}
 			if (!fh.hasUnlimitedSaves && slot != SLOT_QUICKSAVE && triedToCheat(androidContext, fh)) {
-				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded because cheat detection failed for " + fh.describe() + ".");
+				L.warn("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded because cheat detection failed for " + fh.describe() + ".");
 				return LoadSavegameResult.cheatingDetected;
 			}
 
@@ -116,31 +116,30 @@ public final class Savegames {
 				result = loadWorld(androidContext.getResources(), world, controllers, androidContext, fos, fh);
 			} catch (IOException | DigestException e) {
 				lastLoadFailureMessage = e.getMessage() != null ? e.getMessage() : e.toString();
-				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded from " + fh.describe() + ".", e);
+				L.warn("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded from " + fh.describe() + ": " + e);
 				return LoadSavegameResult.unknownError;
 			} finally {
-				try {
-					fos.close();
-				} catch (IOException e) {
-					debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): failed to close the save file after loading.", e);
-				}
+				fos.close();
 			}
+
 			if (result == LoadSavegameResult.savegameIsFromAFutureVersion) {
-				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded because savegame version " + fh.fileversion + " is newer than current version " + AndorsTrailApplication.CURRENT_VERSION + ".");
+				L.warn("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded because savegame version " + fh.fileversion + " is newer than current version " + AndorsTrailApplication.CURRENT_VERSION + ".");
 			}
+
 			if (result == LoadSavegameResult.success && slot != SLOT_QUICKSAVE && !world.model.statistics.hasUnlimitedSaves()) {
 				// save to the quicksave slot before deleting the file
 				if (!saveWorld(world, androidContext, SLOT_QUICKSAVE)) {
-					debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene loaded, but quicksaving before deleting the original save file failed.");
+					L.warn("Savegames.loadWorld(slot=" + slot + "): scene loaded, but quicksaving before deleting the original save file failed.");
 					return LoadSavegameResult.unknownError;
 				}
-				getSlotFile(slot, androidContext).delete();
+
+				boolean b = getSlotFile(slot, androidContext).delete();
 				writeCheatCheck(androidContext, DENY_LOADING_BECAUSE_GAME_IS_CURRENTLY_PLAYED, fh.playerId);
 			}
 			return result;
 		} catch (IOException e) {
 			lastLoadFailureMessage = e.getMessage() != null ? e.getMessage() : e.toString();
-			debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file or scene cannot be loaded.", e);
+			debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded." , e);
 			return LoadSavegameResult.unknownError;
 		}
 	}
@@ -149,18 +148,12 @@ public final class Savegames {
 		return lastLoadFailureMessage;
 	}
 
-	private static void debugLoadFailure(String message) {
-		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-			L.debug(message);
-		}
-	}
-
 	private static void debugLoadFailure(String message, Throwable e) {
 		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
 			StringWriter sw = new StringWriter();
 			PrintWriter pw = new PrintWriter(sw);
 			e.printStackTrace(pw);
-			L.debug(message + " " + e.toString() + "\n" + sw.toString());
+			L.debug(message + " " + e + "\n" + sw);
 		}
 	}
 
@@ -315,7 +308,7 @@ public final class Savegames {
 			fos.close();
 			return header;
 		} catch (Exception e) {
-			debugLoadFailure("Savegames.quickload(slot=" + slot + "): save file cannot be loaded.", e);
+			debugLoadFailure("Savegames.quickload(slot=" + slot + "): save file cannot be loaded." , e);
 			return null;
 		}
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
@@ -99,33 +99,59 @@ public final class Savegames {
 		try {
 			FileHeader fh = quickload(androidContext, slot);
 			if(fh == null) {
+				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded because it is missing or unreadable.");
 				return LoadSavegameResult.unknownError;
 			}
 			if (!fh.hasUnlimitedSaves && slot != SLOT_QUICKSAVE && triedToCheat(androidContext, fh)) {
+				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file cannot be loaded because cheat detection failed for " + fh.describe() + ".");
 				return LoadSavegameResult.cheatingDetected;
 			}
 
 			FileInputStream fos = getInputFile(androidContext, slot);
-			LoadSavegameResult result = loadWorld(androidContext.getResources(), world, controllers, androidContext, fos, fh);
-			fos.close();
+			LoadSavegameResult result;
+			try {
+				result = loadWorld(androidContext.getResources(), world, controllers, androidContext, fos, fh);
+			} catch (IOException | DigestException e) {
+				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded from " + fh.describe() + ".", e);
+				return LoadSavegameResult.unknownError;
+			} finally {
+				try {
+					fos.close();
+				} catch (IOException e) {
+					debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): failed to close the save file after loading.", e);
+				}
+			}
+			if (result == LoadSavegameResult.savegameIsFromAFutureVersion) {
+				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded because savegame version " + fh.fileversion + " is newer than current version " + AndorsTrailApplication.CURRENT_VERSION + ".");
+			}
 			if (result == LoadSavegameResult.success && slot != SLOT_QUICKSAVE && !world.model.statistics.hasUnlimitedSaves()) {
 				// save to the quicksave slot before deleting the file
 				if (!saveWorld(world, androidContext, SLOT_QUICKSAVE)) {
+					debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene loaded, but quicksaving before deleting the original save file failed.");
 					return LoadSavegameResult.unknownError;
 				}
 				getSlotFile(slot, androidContext).delete();
 				writeCheatCheck(androidContext, DENY_LOADING_BECAUSE_GAME_IS_CURRENTLY_PLAYED, fh.playerId);
 			}
 			return result;
-		} catch (IOException | DigestException e) {
-			if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
-				L.log("Error loading world: " + e.toString());
-				StringWriter sw = new StringWriter();
-				PrintWriter pw = new PrintWriter(sw);
-				e.printStackTrace(pw);
-				L.log("Load error: " + sw.toString());
-			}
+		} catch (IOException e) {
+			debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): save file or scene cannot be loaded.", e);
 			return LoadSavegameResult.unknownError;
+		}
+	}
+
+	private static void debugLoadFailure(String message) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			L.debug(message);
+		}
+	}
+
+	private static void debugLoadFailure(String message, Throwable e) {
+		if (AndorsTrailApplication.DEVELOPMENT_DEBUGMESSAGES) {
+			StringWriter sw = new StringWriter();
+			PrintWriter pw = new PrintWriter(sw);
+			e.printStackTrace(pw);
+			L.debug(message + " " + e.toString() + "\n" + sw.toString());
 		}
 	}
 
@@ -280,6 +306,7 @@ public final class Savegames {
 			fos.close();
 			return header;
 		} catch (Exception e) {
+			debugLoadFailure("Savegames.quickload(slot=" + slot + "): save file cannot be loaded.", e);
 			return null;
 		}
 	}

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/savegames/Savegames.java
@@ -116,7 +116,7 @@ public final class Savegames {
 				result = loadWorld(androidContext.getResources(), world, controllers, androidContext, fos, fh);
 			} catch (IOException | DigestException e) {
 				lastLoadFailureMessage = e.getMessage() != null ? e.getMessage() : e.toString();
-				L.warn("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded from " + fh.describe() + ": " + e);
+				debugLoadFailure("Savegames.loadWorld(slot=" + slot + "): scene cannot be loaded from " + fh.describe() + ".", e);
 				return LoadSavegameResult.unknownError;
 			} finally {
 				fos.close();
@@ -153,7 +153,7 @@ public final class Savegames {
 			StringWriter sw = new StringWriter();
 			PrintWriter pw = new PrintWriter(sw);
 			e.printStackTrace(pw);
-			L.debug(message + " " + e + "\n" + sw);
+			L.warn(message + " " + e + "\n" + sw);
 		}
 	}
 
@@ -308,6 +308,7 @@ public final class Savegames {
 			fos.close();
 			return header;
 		} catch (Exception e) {
+			lastLoadFailureMessage = e.getMessage() != null ? e.getMessage() : e.toString();
 			debugLoadFailure("Savegames.quickload(slot=" + slot + "): save file cannot be loaded." , e);
 			return null;
 		}

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -17,7 +17,8 @@
 
 	<string name="dialog_loading_message">Loading resources…</string>
 	<string name="dialog_loading_failed_title">Load Failed</string>
-	<string name="dialog_loading_failed_message">Andor\'s Trail was unable to load the savegame file.\n\n:(\n\nThe file may be damaged or incomplete.</string>
+	<string name="dialog_loading_failed_message">Andor\'s Trail was unable to load the savegame file.\n\n:(\n\nThe file may be damaged or incomplete.\n\nPlease reach out on our Forum or Discord for assistance.</string>
+	<string name="dialog_loading_failed_details">An error was encountered loading the savegame file.\n\n%s\n\nPlease take a screenshot and report this error on our Discord on our Forum or Discord.</string>
 	<string name="dialog_loading_failed_incorrectversion">Andor\'s Trail was unable to load the savegame file. This savegame file is created with a newer version than what is currently running.</string>
 	<string name="dialog_loading_failed_cheat">Andor\'s Trail was unable to load the savegame file. This savegame file has already been continued.</string>
 	<string name="dialog_androidtv_title">Welcome Android TV Players!</string>

--- a/AndorsTrail/res/values/strings.xml
+++ b/AndorsTrail/res/values/strings.xml
@@ -17,8 +17,8 @@
 
 	<string name="dialog_loading_message">Loading resources…</string>
 	<string name="dialog_loading_failed_title">Load Failed</string>
-	<string name="dialog_loading_failed_message">Andor\'s Trail was unable to load the savegame file.\n\n:(\n\nThe file may be damaged or incomplete.\n\nPlease reach out on our Forum or Discord for assistance.</string>
-	<string name="dialog_loading_failed_details">An error was encountered loading the savegame file.\n\n%s\n\nPlease take a screenshot and report this error on our Discord on our Forum or Discord.</string>
+	<string name="dialog_loading_failed_message">Andor\'s Trail was unable to load the savegame file.\n\n:(\n\nThe file may be damaged or incomplete.\n\nPlease reach out on our Forums or Discord for assistance.</string>
+	<string name="dialog_loading_failed_details">An error was encountered loading the savegame file:\n\n%s\n\nPlease take a screenshot and report this error on our Forums or Discord.</string>
 	<string name="dialog_loading_failed_incorrectversion">Andor\'s Trail was unable to load the savegame file. This savegame file is created with a newer version than what is currently running.</string>
 	<string name="dialog_loading_failed_cheat">Andor\'s Trail was unable to load the savegame file. This savegame file has already been continued.</string>
 	<string name="dialog_androidtv_title">Welcome Android TV Players!</string>


### PR DESCRIPTION
This pull request introduces significant improvements to the game's savegame loading process, focusing on better error handling, clearer user messaging, and stricter validation of savegame data. The changes enhance both developer diagnostics and user experience when savegame loading fails, especially during development and testing.

**Error handling and reporting improvements:**

* Added a mechanism to capture and store detailed error messages when savegame loading fails, making them available for display and logging. (`Savegames.java`, `LoadingActivity.java`) [[1]](diffhunk://#diff-756c8cf9172d711ceaaee64f8ec3df0c73f3e7f100e342a4525ebb23fd315be1R52-R53) [[2]](diffhunk://#diff-756c8cf9172d711ceaaee64f8ec3df0c73f3e7f100e342a4525ebb23fd315be1R101-R156) [[3]](diffhunk://#diff-3235c7aed39e634841b8af150eacf7eb07f5fb883107d82a0712a38145933917L168-R176) [[4]](diffhunk://#diff-756c8cf9172d711ceaaee64f8ec3df0c73f3e7f100e342a4525ebb23fd315be1R311-R312)
* Updated the loading failure dialog to show detailed error information (in development mode) and encourage users to seek help, including a new string resource for detailed failure messages. (`LoadingActivity.java`, `strings.xml`) [[1]](diffhunk://#diff-3235c7aed39e634841b8af150eacf7eb07f5fb883107d82a0712a38145933917L168-R176) [[2]](diffhunk://#diff-9a3db8d66ef0cb958ffc28e594aaf1609187fddf6bb9f713af38b1f57c309677L20-R21)

**Stricter validation and fail-fast behavior:**

* Changed map loading logic to throw an error if a savegame references an unknown map, ensuring content bugs are caught early in development. (`MapCollection.java`)
* Improved spawn area loading in `PredefinedMap` to throw an error in development if an unknown spawn area is found, and to gracefully skip it in production, preventing crashes for end-users. (`PredefinedMap.java`) [[1]](diffhunk://#diff-039ef57357a1fcc8504c2a5968ce4ec6f412c3027dae1d06e6b86d2465a1656fL276-R309) [[2]](diffhunk://#diff-039ef57357a1fcc8504c2a5968ce4ec6f412c3027dae1d06e6b86d2465a1656fR23)

**User-facing message improvements:**

* Enhanced the standard loading failure message to direct users to the Forums or Discord for help, and added a new message template for detailed error reporting. (`strings.xml`)