### PR TITLE
Defer onPause() quicksaves until map transition completes.  Resolves …

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/activity/MainActivity.java
@@ -80,6 +80,7 @@ public final class MainActivity
 	private WeakReference<Toast> lastToast = null;
 	//private ContextMenuInfo lastSelectedMenu = null;
 	private OnLongClickListener quickButtonLongClickListener = null;
+	private boolean deferredQuicksave = false;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -176,6 +177,18 @@ public final class MainActivity
 		return Savegames.saveWorld(world, this, slot);
 	}
 
+	private void saveQuicksave() {
+		if (save(Savegames.SLOT_QUICKSAVE)) {
+			deferredQuicksave = false;
+		}
+	}
+
+	private void saveDeferredQuicksaveIfNeeded() {
+		if (!deferredQuicksave) return;
+		if (controllers.movementController.isMapTransitionInProgress()) return;
+		saveQuicksave();
+	}
+
 	@Override
 	protected void onStart() {
 		super.onStart();
@@ -194,8 +207,11 @@ public final class MainActivity
 		super.onPause();
 		controllers.gameRoundController.onMainActivityPaused();
 		controllers.movementController.stopMovement();
-
-		save(Savegames.SLOT_QUICKSAVE);
+		if (controllers.movementController.isMapTransitionInProgress()) {
+			deferredQuicksave = true;
+		} else {
+			saveQuicksave();
+		}
 	}
 
 	@Override
@@ -206,6 +222,9 @@ public final class MainActivity
 		if (world.model.statistics.isDead()) this.finish();
 		else {
 			controllers.gameRoundController.onMainActivityResumed();
+			// It's possible the pause() quicksave was deferred because the map was in transition.  If
+			// so, we do it now so the new map is saved.
+			saveDeferredQuicksaveIfNeeded();
 			updateStatus();
 		}
 	}
@@ -356,7 +375,10 @@ public final class MainActivity
 	public void onPlayerMoved(PredefinedMap map, Coord newPosition, Coord previousPosition) { }
 
 	@Override
-	public void onPlayerEnteredNewMap(PredefinedMap map, Coord p) { }
+	public void onPlayerEnteredNewMap(PredefinedMap map, Coord p) {
+		// If a quicksave was delayed because the map was still transitioning, do it now.
+		saveDeferredQuicksaveIfNeeded();
+	}
 
 	@Override
 	public void onCombatStarted() {

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -76,6 +76,10 @@ public final class MovementController implements TimedMessageTask.Callback {
 
 		};
 
+		if (mapTransitionInProgress) {
+			L.error("placePlayerAsyncAt called while a map transition is already in progress");
+			return;
+		}
 		controllers.gameRoundController.acquirePause(PauseReason.MAP_TRANSITION);
 		mapTransitionInProgress = true;
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/MovementController.java
@@ -28,6 +28,7 @@ public final class MovementController implements TimedMessageTask.Callback {
 	private final WorldContext world;
 	//TODO restore final modifier before release
 	private TimedMessageTask movementHandler;
+	private volatile boolean mapTransitionInProgress = false;
 	public final PlayerMovementListeners playerMovementListeners = new PlayerMovementListeners();
 
 	public MovementController(ControllerContext controllers, WorldContext world) {
@@ -43,7 +44,6 @@ public final class MovementController implements TimedMessageTask.Callback {
 	}
 
 	public void placePlayerAsyncAt(final MapObject.MapObjectType objectType, final String mapName, final String placeName, final int offset_x, final int offset_y) {
-
 		AsyncTask<Void, Void, Void> task = new AsyncTask<Void, Void, Void>() {
 			private boolean mapLoadFailed = false;  // (1) flag to carry failure to onPostExecute
 
@@ -67,6 +67,7 @@ public final class MovementController implements TimedMessageTask.Callback {
 				stopMovement();
 				// (4) always release the pause — timer can never get stuck
 				controllers.gameRoundController.releasePause(PauseReason.MAP_TRANSITION);
+				mapTransitionInProgress = false;
 				if (!mapLoadFailed) {
 					playerMovementListeners.onPlayerEnteredNewMap(
 							world.model.currentMaps.map, world.model.player.position);
@@ -76,6 +77,8 @@ public final class MovementController implements TimedMessageTask.Callback {
 		};
 
 		controllers.gameRoundController.acquirePause(PauseReason.MAP_TRANSITION);
+		mapTransitionInProgress = true;
+
 		task.execute();
 	}
 
@@ -302,8 +305,13 @@ public final class MovementController implements TimedMessageTask.Callback {
 		placePlayerAt(res, MapObject.MapObjectType.rest, world.model.player.getSpawnMap(), world.model.player.getSpawnPlace(), 0, 0);
 		playerMovementListeners.onPlayerEnteredNewMap(world.model.currentMaps.map, world.model.player.position);
 	}
+
 	public void respawnPlayerAsync() {
 		placePlayerAsyncAt(MapObject.MapObjectType.rest, world.model.player.getSpawnMap(), world.model.player.getSpawnPlace(), 0, 0);
+	}
+
+	public boolean isMapTransitionInProgress() {
+		return mapTransitionInProgress;
 	}
 
 	public void moveBlockedActors(PredefinedMap map, LayeredTileMap tileMap) {


### PR DESCRIPTION
…bug with passive achievement dialogue causing indeterminate save

This pull request improves the quicksave system to avoid saving during map transitions, ensuring data integrity and preventing potential save corruption. The main changes introduce a mechanism to defer quicksaves if a map transition is in progress and to complete the save as soon as it is safe. Additionally, it adds tracking of map transition state in the movement controller.

**Quicksave Deferral and Execution:**

* Added a `deferredQuicksave` flag and methods (`saveQuicksave`, `saveDeferredQuicksaveIfNeeded`) in `MainActivity` to defer and later perform quicksaves if a map transition is in progress. Now, quicksaves are only performed when it is safe, either immediately or after the transition completes. [[1]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430R83) [[2]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430R180-R191) [[3]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430L197-R214) [[4]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430R225-R227) [[5]](diffhunk://#diff-edf20dfa7dc212cd0ef74889a139cbc64f432f91c8931c9a932fffd0be1ac430L359-R381)

**Map Transition State Tracking:**

* Introduced a `mapTransitionInProgress` flag in `MovementController`, which is set to `true` when a map transition starts and reset to `false` when it ends. This allows other parts of the code to check if a transition is ongoing. [[1]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfR31) [[2]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfR80-R81) [[3]](diffhunk://#diff-a6d73bdf798c21bcd9147ce216aa36ad83ef6206a071f16b4af23dd805d5a8bfR70)
* Added the `isMapTransitionInProgress()` method to `MovementController` to expose the current state of map transitions.

These changes together ensure that quicksaves are not performed during potentially unsafe moments, improving overall game stability.