### PR TITLE
Resume combat when no pause reasons remain

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -21,6 +21,14 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	}
 
 	/**
+	 * Callback used to resume combat after the last blocking pause is released.
+	 * Implemented as interface to support unit testing.
+	 */
+	interface CombatResumeHook {
+		void resumeCombatIfNeeded();
+	}
+
+	/**
 	 * Production timer implementation backed by {@link TimedMessageTask}.
 	 */
 	private static final class TimedRoundTimer implements RoundTimer {
@@ -50,6 +58,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 
 	private final ControllerContext controllers;
 	private final WorldContext world;
+	private final CombatResumeHook combatResumeHook;
 	private final RoundTimer roundTimer;
 	private final EnumSet<PauseReason> activePauses = EnumSet.noneOf(PauseReason.class);
 	public final GameRoundListeners gameRoundListeners = new GameRoundListeners();
@@ -60,6 +69,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	public GameRoundController(ControllerContext controllers, WorldContext world) {
 		this.controllers = controllers;
 		this.world = world;
+		this.combatResumeHook = controllers.combatController::resumeCombatIfNeeded;
 		this.roundTimer = new TimedRoundTimer(new TimedMessageTask(this, Constants.TICK_DELAY, true));
 		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
 		updateTimerState();
@@ -68,9 +78,10 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	/**
 	 * Test-only constructor that allows the round timer implementation to be replaced.
 	 */
-	GameRoundController(ControllerContext controllers, WorldContext world, RoundTimer roundTimer) {
+	GameRoundController(ControllerContext controllers, WorldContext world, CombatResumeHook combatResumeHook, RoundTimer roundTimer) {
 		this.controllers = controllers;
 		this.world = world;
+		this.combatResumeHook = combatResumeHook;
 		this.roundTimer = roundTimer;
 		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
 		updateTimerState();
@@ -140,7 +151,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 		activePauses.remove(reason);
 		updateTimerState();
 		if (!hasPauseReasons()) {
-			controllers.combatController.resumeCombatIfNeeded();
+			combatResumeHook.resumeCombatIfNeeded();
 		}
 	}
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -139,6 +139,9 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 		}
 		activePauses.remove(reason);
 		updateTimerState();
+		if (!hasPauseReasons()) {
+			controllers.combatController.resumeCombatIfNeeded();
+		}
 	}
 
 	/**
@@ -156,7 +159,6 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	 */
 	public void onMainActivityResumed() {
 		releasePause(PauseReason.ACTIVITY_HIDDEN);
-		controllers.combatController.resumeCombatIfNeeded();
 	}
 
 	/**
@@ -201,6 +203,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 			roundTimer.stop();
 			return;
 		}
+		// TODO: Don't use visibility flag as proxy for pause state, or at least rename it.
 		world.model.uiSelections.isMainActivityVisible = !hasPauseReasons();
 		if (hasPauseReasons() || world.model.uiSelections.isInCombat) {
 			roundTimer.stop();

--- a/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
+++ b/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
@@ -29,8 +29,21 @@ public final class GameRoundControllerTest {
 		}
 	}
 
-	private static GameRoundController createController(WorldContext world, FakeRoundTimer timer) {
-		return new GameRoundController(null, world, timer);
+	private static final class FakeCombatResumeHook implements GameRoundController.CombatResumeHook {
+		private int calls = 0;
+
+		@Override
+		public void resumeCombatIfNeeded() {
+			calls++;
+		}
+
+		private void reset() {
+			calls = 0;
+		}
+	}
+
+	private static GameRoundController createController(WorldContext world, FakeRoundTimer timer, FakeCombatResumeHook hook) {
+		return new GameRoundController(null, world, hook, timer);
 	}
 
 	private static WorldContext createLoadedWorld() {
@@ -43,8 +56,9 @@ public final class GameRoundControllerTest {
 	public void constructorIsSafeBeforeModelLoads() {
 		WorldContext world = new WorldContext();
 		FakeRoundTimer timer = new FakeRoundTimer();
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
 
-		GameRoundController controller = createController(world, timer);
+		GameRoundController controller = createController(world, timer, hook);
 
 		assertFalse(controller.onTick(null));
 		assertEquals(0, timer.startCount);
@@ -56,21 +70,24 @@ public final class GameRoundControllerTest {
 	public void releasingActivityHiddenStartsTimerWhenNoOtherPauseExists() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
-
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
 
 		assertTrue(world.model.uiSelections.isMainActivityVisible);
 		assertEquals(1, timer.startCount);
 		assertTrue(timer.running);
+		assertEquals(1, hook.calls);
 	}
 
 	@Test
 	public void mapTransitionReleaseDoesNotRestartTimerWhileBlockingActivityIsActive() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_ACTIVITY);
 		controller.acquirePause(GameRoundController.PauseReason.MAP_TRANSITION);
@@ -79,19 +96,23 @@ public final class GameRoundControllerTest {
 		assertFalse(timer.running);
 		assertEquals(1, timer.startCount);
 		assertEquals(4, timer.stopCount);
+		assertEquals(0, hook.calls);
 
 		controller.releasePause(GameRoundController.PauseReason.BLOCKING_ACTIVITY);
 
 		assertTrue(timer.running);
 		assertEquals(2, timer.startCount);
+		assertEquals(1, hook.calls);
 	}
 
 	@Test
 	public void combatStateChangeStopsAndRestartsTimer() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		world.model.uiSelections.isInCombat = true;
 		controller.onCombatStateChanged();
@@ -107,8 +128,10 @@ public final class GameRoundControllerTest {
 	public void blockingDialogClearsMainActivityVisibilityUntilReleased() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
 
@@ -119,14 +142,17 @@ public final class GameRoundControllerTest {
 
 		assertTrue(world.model.uiSelections.isMainActivityVisible);
 		assertTrue(timer.running);
+		assertEquals(1, hook.calls);
 	}
 
 	@Test(expected = AssertionError.class)
 	public void duplicateAcquireFailsFastInDebugBuilds() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
@@ -136,8 +162,10 @@ public final class GameRoundControllerTest {
 	public void unmatchedReleaseFailsFastInDebugBuilds() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.releasePause(GameRoundController.PauseReason.MAP_TRANSITION);
 	}


### PR DESCRIPTION
Fix a problem with combat not being resumed correctly after certain pause states (e.g., bringing up combat log).   This is a small patch to restore previous behavior; a cleaner fix to disconnect the visibility flag from combat would be better, but this has less risk.

This pull request refactors how combat resumes after all pause conditions are cleared in the `GameRoundController`. It introduces a new `CombatResumeHook` interface to decouple the combat resume logic, making the controller more testable and flexible. The test suite is updated to use this new hook, allowing for more precise verification of combat resume behavior.

**Combat Resume Logic Refactor:**

* Added a `CombatResumeHook` interface to abstract the action of resuming combat, improving testability and separation of concerns in `GameRoundController`.
* Updated `GameRoundController` to use `CombatResumeHook` for resuming combat when all pauses are released, instead of calling the combat controller directly. [[1]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R61) [[2]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R72) [[3]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5L71-R84) [[4]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R153-R155) [[5]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5L159)

**Testing Improvements:**

* Refactored tests in `GameRoundControllerTest.java` to use a `FakeCombatResumeHook`, allowing assertions on how many times combat resume is triggered. This provides clearer and more reliable test coverage of pause and resume behavior. [[1]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L32-R46) [[2]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1R59-R61) [[3]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L59-R90) [[4]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1R99-R115) [[5]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L110-R134) [[6]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1R145-R155) [[7]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L139-R168)

**Minor Code Maintenance:**

* Added a TODO comment to clarify intent around using the visibility flag as a proxy for pause state in `updateTimerState()`.