### PR TITLE
Fix combat resumption after pause

### DIFF
--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -21,6 +21,14 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	}
 
 	/**
+	 * Callback used to resume combat after the last blocking pause is released.
+	 * Implemented as interface to support unit testing.
+	 */
+	interface CombatResumeHook {
+		void resumeCombatIfNeeded();
+	}
+
+	/**
 	 * Production timer implementation backed by {@link TimedMessageTask}.
 	 */
 	private static final class TimedRoundTimer implements RoundTimer {
@@ -50,6 +58,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 
 	private final ControllerContext controllers;
 	private final WorldContext world;
+	private final CombatResumeHook combatResumeHook;
 	private final RoundTimer roundTimer;
 	private final EnumSet<PauseReason> activePauses = EnumSet.noneOf(PauseReason.class);
 	public final GameRoundListeners gameRoundListeners = new GameRoundListeners();
@@ -60,6 +69,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	public GameRoundController(ControllerContext controllers, WorldContext world) {
 		this.controllers = controllers;
 		this.world = world;
+		this.combatResumeHook = controllers.combatController::resumeCombatIfNeeded;
 		this.roundTimer = new TimedRoundTimer(new TimedMessageTask(this, Constants.TICK_DELAY, true));
 		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
 		updateTimerState();
@@ -68,9 +78,10 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	/**
 	 * Test-only constructor that allows the round timer implementation to be replaced.
 	 */
-	GameRoundController(ControllerContext controllers, WorldContext world, RoundTimer roundTimer) {
+	GameRoundController(ControllerContext controllers, WorldContext world, CombatResumeHook combatResumeHook, RoundTimer roundTimer) {
 		this.controllers = controllers;
 		this.world = world;
+		this.combatResumeHook = combatResumeHook;
 		this.roundTimer = roundTimer;
 		activePauses.add(PauseReason.ACTIVITY_HIDDEN);
 		updateTimerState();
@@ -140,7 +151,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 		activePauses.remove(reason);
 		updateTimerState();
 		if (!hasPauseReasons()) {
-			controllers.combatController.resumeCombatIfNeeded();
+			combatResumeHook.resumeCombatIfNeeded();
 		}
 	}
 

--- a/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
+++ b/AndorsTrail/app/src/main/java/com/gpl/rpg/AndorsTrail/controller/GameRoundController.java
@@ -139,6 +139,9 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 		}
 		activePauses.remove(reason);
 		updateTimerState();
+		if (!hasPauseReasons()) {
+			controllers.combatController.resumeCombatIfNeeded();
+		}
 	}
 
 	/**
@@ -156,7 +159,6 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 	 */
 	public void onMainActivityResumed() {
 		releasePause(PauseReason.ACTIVITY_HIDDEN);
-		controllers.combatController.resumeCombatIfNeeded();
 	}
 
 	/**
@@ -201,6 +203,7 @@ public final class GameRoundController implements TimedMessageTask.Callback {
 			roundTimer.stop();
 			return;
 		}
+		// TODO: Don't use visibility flag as proxy for pause state, or at least rename it.
 		world.model.uiSelections.isMainActivityVisible = !hasPauseReasons();
 		if (hasPauseReasons() || world.model.uiSelections.isInCombat) {
 			roundTimer.stop();

--- a/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
+++ b/AndorsTrail/app/src/test/java/com/gpl/rpg/AndorsTrail/controller/GameRoundControllerTest.java
@@ -29,8 +29,21 @@ public final class GameRoundControllerTest {
 		}
 	}
 
-	private static GameRoundController createController(WorldContext world, FakeRoundTimer timer) {
-		return new GameRoundController(null, world, timer);
+	private static final class FakeCombatResumeHook implements GameRoundController.CombatResumeHook {
+		private int calls = 0;
+
+		@Override
+		public void resumeCombatIfNeeded() {
+			calls++;
+		}
+
+		private void reset() {
+			calls = 0;
+		}
+	}
+
+	private static GameRoundController createController(WorldContext world, FakeRoundTimer timer, FakeCombatResumeHook hook) {
+		return new GameRoundController(null, world, hook, timer);
 	}
 
 	private static WorldContext createLoadedWorld() {
@@ -43,8 +56,9 @@ public final class GameRoundControllerTest {
 	public void constructorIsSafeBeforeModelLoads() {
 		WorldContext world = new WorldContext();
 		FakeRoundTimer timer = new FakeRoundTimer();
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
 
-		GameRoundController controller = createController(world, timer);
+		GameRoundController controller = createController(world, timer, hook);
 
 		assertFalse(controller.onTick(null));
 		assertEquals(0, timer.startCount);
@@ -56,21 +70,24 @@ public final class GameRoundControllerTest {
 	public void releasingActivityHiddenStartsTimerWhenNoOtherPauseExists() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
-
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
 
 		assertTrue(world.model.uiSelections.isMainActivityVisible);
 		assertEquals(1, timer.startCount);
 		assertTrue(timer.running);
+		assertEquals(1, hook.calls);
 	}
 
 	@Test
 	public void mapTransitionReleaseDoesNotRestartTimerWhileBlockingActivityIsActive() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_ACTIVITY);
 		controller.acquirePause(GameRoundController.PauseReason.MAP_TRANSITION);
@@ -79,19 +96,23 @@ public final class GameRoundControllerTest {
 		assertFalse(timer.running);
 		assertEquals(1, timer.startCount);
 		assertEquals(4, timer.stopCount);
+		assertEquals(0, hook.calls);
 
 		controller.releasePause(GameRoundController.PauseReason.BLOCKING_ACTIVITY);
 
 		assertTrue(timer.running);
 		assertEquals(2, timer.startCount);
+		assertEquals(1, hook.calls);
 	}
 
 	@Test
 	public void combatStateChangeStopsAndRestartsTimer() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		world.model.uiSelections.isInCombat = true;
 		controller.onCombatStateChanged();
@@ -107,8 +128,10 @@ public final class GameRoundControllerTest {
 	public void blockingDialogClearsMainActivityVisibilityUntilReleased() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
 
@@ -119,14 +142,17 @@ public final class GameRoundControllerTest {
 
 		assertTrue(world.model.uiSelections.isMainActivityVisible);
 		assertTrue(timer.running);
+		assertEquals(1, hook.calls);
 	}
 
 	@Test(expected = AssertionError.class)
 	public void duplicateAcquireFailsFastInDebugBuilds() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
 		controller.acquirePause(GameRoundController.PauseReason.BLOCKING_DIALOG);
@@ -136,8 +162,10 @@ public final class GameRoundControllerTest {
 	public void unmatchedReleaseFailsFastInDebugBuilds() {
 		WorldContext world = createLoadedWorld();
 		FakeRoundTimer timer = new FakeRoundTimer();
-		GameRoundController controller = createController(world, timer);
+		FakeCombatResumeHook hook = new FakeCombatResumeHook();
+		GameRoundController controller = createController(world, timer, hook);
 		controller.releasePause(GameRoundController.PauseReason.ACTIVITY_HIDDEN);
+		hook.reset();
 
 		controller.releasePause(GameRoundController.PauseReason.MAP_TRANSITION);
 	}


### PR DESCRIPTION
Fixes an issue in pause handling in which in-progress combat would not always be resumed after a pause (such as when a dialogue is displayed).  Originally reported at [https://andorstrail.com/viewtopic.php?p=84942#p84942](https://andorstrail.com/viewtopic.php?p=84942#p84942), in which the game would freeze if the combat log is brought up right as combat initiates.

This is not an ideal fix, but has a small footprint that should reduce risks for the release.

** Copilot Description
This pull request refactors the `GameRoundController` to introduce a new `CombatResumeHook` interface, decoupling combat resumption logic from the controller itself and improving testability. The change also updates the unit tests to use this new hook, allowing precise verification of combat resume behavior.

Key changes include:

**Core Refactoring and Decoupling:**
* Introduced the `CombatResumeHook` interface to abstract and encapsulate the logic for resuming combat, making the codebase more modular and easier to test. The production controller now uses a method reference to the actual combat controller, while tests can inject a fake hook. [[1]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R23-R30) [[2]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R61) [[3]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5R72) [[4]](diffhunk://#diff-f2ae28a9e6f2cdfde9e2d9b6bf57ae3f046e83a81f02f516f0fa747f6ba263f5L71-R84)
* Updated `releasePause` to invoke the `CombatResumeHook` when all pause reasons have been cleared, ensuring combat is resumed only when appropriate.
* Removed the direct call to `resumeCombatIfNeeded` from `onMainActivityResumed`, as this is now handled via the hook in `releasePause`.

**Testing Improvements:**
* Refactored unit tests to use a `FakeCombatResumeHook`, enabling verification of when and how often combat resume is triggered. This improves the reliability and clarity of the tests. [[1]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L32-R46) [[2]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1R59-R61) [[3]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L59-R90) [[4]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1R99-R115) [[5]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L110-R134) [[6]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1R145-R155) [[7]](diffhunk://#diff-fe43de9b8e5d20d5a19c83f7e461f92aa3d1a00647ecf9f285e321c4285a5cc1L139-R168)

**Minor Enhancements:**
* Added a TODO comment to clarify the use of the visibility flag as a proxy for pause state, indicating potential future improvements.